### PR TITLE
Persist ship upgrades and remove cannon penalties

### DIFF
--- a/src/main/java/com/talhanation/smallships/entities/AbstractCannonShip.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractCannonShip.java
@@ -92,6 +92,33 @@ public abstract class AbstractCannonShip extends AbstractShipDamage{
         setLeftShootCoolDown(nbt.getInt("LeftShootCoolDown"));
     }
 
+    @Override
+    protected ItemStack createShipItemStack(boolean broken) {
+        ItemStack stack = super.createShipItemStack(broken);
+        if (!broken && !stack.isEmpty()) {
+            CompoundNBT tag = stack.getOrCreateTag();
+            tag.putInt("RightCannonCount", getRightCannonCount());
+            tag.putInt("LeftCannonCount", getLeftCannonCount());
+        }
+        return stack;
+    }
+
+    @Override
+    public void applyItemData(ItemStack stack) {
+        super.applyItemData(stack);
+        CompoundNBT tag = stack.getTag();
+        if (tag != null) {
+            int maxCannons = this.getMaxCannons();
+            int left = MathHelper.clamp(tag.getInt("LeftCannonCount"), 0, maxCannons);
+            int right = MathHelper.clamp(tag.getInt("RightCannonCount"), 0, maxCannons);
+            if (left + right > maxCannons) {
+                right = MathHelper.clamp(maxCannons - left, 0, maxCannons);
+            }
+            this.setLeftCannonCount(left);
+            this.setRightCannonCount(right);
+        }
+    }
+
     ////////////////////////////////////GET////////////////////////////////////
 
     public abstract int getMaxCannons();

--- a/src/main/java/com/talhanation/smallships/entities/AbstractSailShip.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractSailShip.java
@@ -386,7 +386,7 @@ public abstract class AbstractSailShip extends AbstractWaterVehicle {
             setRight(false);
         }
         int sailstate = getSailState();
-        float modifier = 1 - (getBiomesModifier() + getPassengerModifier() + getCannonModifier() + getCargoModifier());
+        float modifier = Math.max(0F, 1 - (getPassengerModifier() + getCargoModifier()));
 
 
         float blockedmodf = 1;
@@ -694,7 +694,15 @@ public abstract class AbstractSailShip extends AbstractWaterVehicle {
         if (broken) {
             stack.getOrCreateTag().putBoolean(BROKEN_TAG, true);
         }
+        stack.getOrCreateTag().putString("SailColor", getSailColor());
         return stack;
+    }
+
+    public void applyItemData(ItemStack stack) {
+        CompoundNBT tag = stack.getTag();
+        if (tag != null && tag.contains("SailColor", 8)) {
+            this.setSailColor(tag.getString("SailColor"));
+        }
     }
 
     public enum Type {

--- a/src/main/java/com/talhanation/smallships/entities/AbstractShipDamage.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractShipDamage.java
@@ -21,6 +21,7 @@ import net.minecraft.particles.ParticleTypes;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvents;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -203,7 +204,21 @@ public abstract class AbstractShipDamage extends AbstractBannerUser {
             Item brokenHullItem = this.getBrokenHullItem();
             return brokenHullItem == null ? ItemStack.EMPTY : new ItemStack(brokenHullItem);
         }
-        return super.createShipItemStack(false);
+        ItemStack stack = super.createShipItemStack(false);
+        if (!stack.isEmpty() && stack.isDamageableItem()) {
+            int damage = MathHelper.clamp(Math.round(this.getShipDamage()), 0, stack.getMaxDamage());
+            stack.setDamageValue(damage);
+        }
+        return stack;
+    }
+
+    @Override
+    public void applyItemData(ItemStack stack) {
+        super.applyItemData(stack);
+        if (stack.isDamageableItem()) {
+            float damage = MathHelper.clamp(stack.getDamageValue(), 0, 100);
+            this.setShipDamage(damage);
+        }
     }
 
     protected abstract Item getBrokenHullItem();

--- a/src/main/java/com/talhanation/smallships/init/ModItems.java
+++ b/src/main/java/com/talhanation/smallships/init/ModItems.java
@@ -20,19 +20,19 @@ public class ModItems {
     public static final RegistryObject<Item> BROKEN_COG_HULL = ITEMS.register("broken_cog_hull", () -> new Item((new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
     public static final RegistryObject<Item> BROKEN_BRIGG_HULL = ITEMS.register("broken_brigg_hull", () -> new Item((new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
 
-    public static final RegistryObject<Item> OAK_COG_ITEM = ITEMS.register("oak_cog", () -> new CogItem(CogEntity.Type.OAK, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
-    public static final RegistryObject<Item> SPRUCE_COG_ITEM = ITEMS.register("spruce_cog", () -> new CogItem(CogEntity.Type.SPRUCE, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
-    public static final RegistryObject<Item> BIRCH_COG_ITEM = ITEMS.register("birch_cog", () -> new CogItem(CogEntity.Type.BIRCH, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
-    public static final RegistryObject<Item> JUNGLE_COG_ITEM = ITEMS.register("jungle_cog", () -> new CogItem(CogEntity.Type.JUNGLE, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
-    public static final RegistryObject<Item> ACACIA_COG_ITEM = ITEMS.register("acacia_cog", () -> new CogItem(CogEntity.Type.ACACIA, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
-    public static final RegistryObject<Item> DARK_OAK_COG_ITEM = ITEMS.register("dark_oak_cog", () -> new CogItem(CogEntity.Type.DARK_OAK, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> OAK_COG_ITEM = ITEMS.register("oak_cog", () -> new CogItem(CogEntity.Type.OAK, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> SPRUCE_COG_ITEM = ITEMS.register("spruce_cog", () -> new CogItem(CogEntity.Type.SPRUCE, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> BIRCH_COG_ITEM = ITEMS.register("birch_cog", () -> new CogItem(CogEntity.Type.BIRCH, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> JUNGLE_COG_ITEM = ITEMS.register("jungle_cog", () -> new CogItem(CogEntity.Type.JUNGLE, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> ACACIA_COG_ITEM = ITEMS.register("acacia_cog", () -> new CogItem(CogEntity.Type.ACACIA, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> DARK_OAK_COG_ITEM = ITEMS.register("dark_oak_cog", () -> new CogItem(CogEntity.Type.DARK_OAK, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
 
-    public static final RegistryObject<Item> OAK_BRIGG_ITEM = ITEMS.register("oak_brigg", () -> new BriggItem(BriggEntity.Type.OAK, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
-    public static final RegistryObject<Item> SPRUCE_BRIGG_ITEM = ITEMS.register("spruce_brigg", () -> new BriggItem(BriggEntity.Type.SPRUCE, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
-    public static final RegistryObject<Item> BIRCH_BRIGG_ITEM = ITEMS.register("birch_brigg", () -> new BriggItem(BriggEntity.Type.BIRCH, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
-    public static final RegistryObject<Item> JUNGLE_BRIGG_ITEM = ITEMS.register("jungle_brigg", () -> new BriggItem(BriggEntity.Type.JUNGLE, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
-    public static final RegistryObject<Item> ACACIA_BRIGG_ITEM = ITEMS.register("acacia_brigg", () -> new BriggItem(BriggEntity.Type.ACACIA, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
-    public static final RegistryObject<Item> DARK_OAK_BRIGG_ITEM = ITEMS.register("dark_oak_brigg", () -> new BriggItem(BriggEntity.Type.DARK_OAK, (new Item.Properties()).stacksTo(1).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> OAK_BRIGG_ITEM = ITEMS.register("oak_brigg", () -> new BriggItem(BriggEntity.Type.OAK, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> SPRUCE_BRIGG_ITEM = ITEMS.register("spruce_brigg", () -> new BriggItem(BriggEntity.Type.SPRUCE, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> BIRCH_BRIGG_ITEM = ITEMS.register("birch_brigg", () -> new BriggItem(BriggEntity.Type.BIRCH, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> JUNGLE_BRIGG_ITEM = ITEMS.register("jungle_brigg", () -> new BriggItem(BriggEntity.Type.JUNGLE, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> ACACIA_BRIGG_ITEM = ITEMS.register("acacia_brigg", () -> new BriggItem(BriggEntity.Type.ACACIA, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
+    public static final RegistryObject<Item> DARK_OAK_BRIGG_ITEM = ITEMS.register("dark_oak_brigg", () -> new BriggItem(BriggEntity.Type.DARK_OAK, new Item.Properties().stacksTo(1).durability(100).tab(ItemGroup.TAB_TRANSPORTATION)));
 
     /*
     public static final RegistryObject<Item> OAK_ROWBOAT_ITEM =         createRowBoat("oak", AbstractRowBoatEntity.Type.OAK, true);

--- a/src/main/java/com/talhanation/smallships/items/BriggItem.java
+++ b/src/main/java/com/talhanation/smallships/items/BriggItem.java
@@ -74,6 +74,7 @@ public class BriggItem extends Item {
                     return ActionResult.fail(itemstack);
                 } else {
                     if (!worldIn.isClientSide) {
+                        boatentity.applyItemData(itemstack);
                         worldIn.addFreshEntity(boatentity);
                         if (boatentity.getStatus().equals(AbstractWaterVehicle.Status.IN_WATER)) {
                             worldIn.playSound(null, boatentity.getX(), boatentity.getY(), boatentity.getZ(), SoundEvents.PLAYER_SPLASH, SoundCategory.BLOCKS, 0.75F, 0.8F);

--- a/src/main/java/com/talhanation/smallships/items/CogItem.java
+++ b/src/main/java/com/talhanation/smallships/items/CogItem.java
@@ -74,6 +74,7 @@ public class CogItem extends Item {
                     return ActionResult.fail(itemstack);
                 } else {
                     if (!worldIn.isClientSide) {
+                        boatentity.applyItemData(itemstack);
                         worldIn.addFreshEntity(boatentity);
                         if (boatentity.getStatus().equals(AbstractWaterVehicle.Status.IN_WATER)) {
                             worldIn.playSound(null, boatentity.getX(), boatentity.getY(), boatentity.getZ(), SoundEvents.PLAYER_SPLASH, SoundCategory.BLOCKS, 0.75F, 0.8F);


### PR DESCRIPTION
## Summary
- stop applying cannon and biome modifiers when computing sail ship speed
- persist sail color, cannon counts, and accumulated damage on the ship item when picking up vessels
- restore the stored data when replacing a ship and make boat items damageable so durability reflects hull damage

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65 in build.gradle)*

------
https://chatgpt.com/codex/tasks/task_b_68cffd1f5e24832ea2497a699f5e9b4d