### PR TITLE
Fix passenger rotation setter usage

### DIFF
--- a/src/main/java/com/talhanation/smallships/entities/AbstractBasicShip.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractBasicShip.java
@@ -100,7 +100,7 @@ public abstract class AbstractBasicShip extends AbstractShipDamage {
         Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
                 .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
         passenger.setPos(this.getX() + rotated.x, this.getY() + ridingOffset, this.getZ() + rotated.z);
-        passenger.setYRot(passenger.yRot + this.deltaRotation);
+        passenger.yRot += this.deltaRotation;
         passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
         applyYawToEntity(passenger);
     }

--- a/src/main/java/com/talhanation/smallships/entities/WarGalleyEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/WarGalleyEntity.java
@@ -250,7 +250,7 @@ public class WarGalleyEntity extends AbstractCannonShip {
         Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
                 .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
         passenger.setPos(this.getX() + rotated.x, this.getY() + ridingOffset, this.getZ() + rotated.z);
-        passenger.setYRot(passenger.yRot + this.deltaRotation);
+        passenger.yRot += this.deltaRotation;
         passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
         applyYawToEntity(passenger);
     }


### PR DESCRIPTION
## Summary
- replace the unavailable Entity#setYRot call in AbstractBasicShip with direct yaw adjustments compatible with MC 1.16 mappings
- update WarGalleyEntity to match the available rotation API

## Testing
- ./gradlew compileJava *(fails: Unsupported class file major version 65 with the provided JDK)*

------
https://chatgpt.com/codex/tasks/task_b_68d02a080654832eb162276d57ed1fee