### PR TITLE
Fix sail rendering and orientation for new ships

### DIFF
--- a/src/main/java/com/talhanation/smallships/client/events/ClientRenderEvent.java
+++ b/src/main/java/com/talhanation/smallships/client/events/ClientRenderEvent.java
@@ -1,9 +1,10 @@
 package com.talhanation.smallships.client.events;
 
 import com.talhanation.smallships.Main;
-import com.talhanation.smallships.client.model.ModelCogSail;
 import com.talhanation.smallships.client.model.ModelDhow;
+import com.talhanation.smallships.client.model.ModelDhowSail;
 import com.talhanation.smallships.client.model.ModelDrakkar;
+import com.talhanation.smallships.client.model.ModelDrakkarSail;
 import com.talhanation.smallships.client.model.ModelRowBoat;
 import com.talhanation.smallships.client.render.RenderCannonBall;
 import com.talhanation.smallships.client.render.RenderEntityBasicShip;
@@ -25,9 +26,9 @@ public class ClientRenderEvent {
     public static void clientsetup(FMLClientSetupEvent event){
         RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.COG.get(), RenderEntityCog::new );
         RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.BRIGG.get(), RenderEntityBrigg::new );
-        RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.ROWBOAT.get(), manager -> new RenderEntityBasicShip<>(manager, new ModelRowBoat(), ModelCogSail::new, 0.8F));
-        RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.DHOW.get(), manager -> new RenderEntityBasicShip<>(manager, new ModelDhow(), ModelCogSail::new, 1.0F));
-        RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.DRAKKAR.get(), manager -> new RenderEntityBasicShip<>(manager, new ModelDrakkar(), ModelCogSail::new, 1.1F));
+        RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.ROWBOAT.get(), manager -> new RenderEntityBasicShip<>(manager, new ModelRowBoat(), null, 0.8F));
+        RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.DHOW.get(), manager -> new RenderEntityBasicShip<>(manager, new ModelDhow(), ModelDhowSail::new, 1.0F));
+        RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.DRAKKAR.get(), manager -> new RenderEntityBasicShip<>(manager, new ModelDrakkar(), ModelDrakkarSail::new, 1.1F));
         RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.GALLEY.get(), RenderEntityGalley::new);
         RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.WAR_GALLEY.get(), RenderEntityWarGalley::new);
         RenderingRegistry.registerEntityRenderingHandler(ModEntityTypes.CANNON_BALL.get(), RenderCannonBall::new );

--- a/src/main/java/com/talhanation/smallships/client/model/ModelDhow.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelDhow.java
@@ -2459,9 +2459,45 @@ public class ModelDhow extends EntityModel<AbstractBannerUser> {
 
    @Override
    public void renderToBuffer(MatrixStack matrixStackIn, IVertexBuilder bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
+      boolean sail0Left = this.Sail_z0_1.visible;
+      boolean sail0Right = this.Sail_z0_2.visible;
+      boolean sail1Left = this.segel_z1_1.visible;
+      boolean sail1Right = this.segel_z1_2.visible;
+      boolean sail2Left = this.segel_z2_1.visible;
+      boolean sail2Right = this.segel_z2_2.visible;
+      boolean sail3Left = this.segel_z3_1.visible;
+      boolean sail3Right = this.segel_z3_2.visible;
+      boolean sail4Left = this.segel_z4_1.visible;
+      boolean sail4Right = this.segel_z4_2.visible;
+      boolean rope = this.seil_0.visible;
+
+      this.Sail_z0_1.visible = false;
+      this.Sail_z0_2.visible = false;
+      this.segel_z1_1.visible = false;
+      this.segel_z1_2.visible = false;
+      this.segel_z2_1.visible = false;
+      this.segel_z2_2.visible = false;
+      this.segel_z3_1.visible = false;
+      this.segel_z3_2.visible = false;
+      this.segel_z4_1.visible = false;
+      this.segel_z4_2.visible = false;
+      this.seil_0.visible = false;
+
       ImmutableList.of(this.Dhow).forEach((modelRenderer) -> {
          modelRenderer.render(matrixStackIn, bufferIn, packedLightIn, packedOverlayIn, red, green, blue, alpha);
       });
+
+      this.Sail_z0_1.visible = sail0Left;
+      this.Sail_z0_2.visible = sail0Right;
+      this.segel_z1_1.visible = sail1Left;
+      this.segel_z1_2.visible = sail1Right;
+      this.segel_z2_1.visible = sail2Left;
+      this.segel_z2_2.visible = sail2Right;
+      this.segel_z3_1.visible = sail3Left;
+      this.segel_z3_2.visible = sail3Right;
+      this.segel_z4_1.visible = sail4Left;
+      this.segel_z4_2.visible = sail4Right;
+      this.seil_0.visible = rope;
    }
 
    @Override

--- a/src/main/java/com/talhanation/smallships/client/model/ModelDhowSail.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelDhowSail.java
@@ -1,0 +1,55 @@
+package com.talhanation.smallships.client.model;
+
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.vertex.IVertexBuilder;
+import com.talhanation.smallships.entities.AbstractBannerUser;
+import com.talhanation.smallships.entities.AbstractSailShip;
+import net.minecraft.client.renderer.model.ModelRenderer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+@OnlyIn(Dist.CLIENT)
+public class ModelDhowSail extends ModelSail {
+
+    private final ModelDhow model;
+
+    public ModelDhowSail() {
+        this.model = new ModelDhow();
+    }
+
+    @Override
+    public void setupAnim(AbstractSailShip entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch) {
+        if (entity instanceof AbstractBannerUser) {
+            model.setupAnim((AbstractBannerUser) entity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
+        }
+    }
+
+    @Override
+    public void renderToBuffer(MatrixStack matrixStack, IVertexBuilder buffer, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.seil_0, model.Dhow);
+
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.Sail_z0_1, model.Dhow, model.mast_1, model.untermast_1);
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.segel_z1_1, model.Dhow, model.mast_1);
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.segel_z2_1, model.Dhow, model.mast_1);
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.segel_z3_1, model.Dhow, model.mast_1);
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.segel_z4_1, model.Dhow, model.mast_1);
+
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.Sail_z0_2, model.Dhow, model.mast_2, model.untermast_2);
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.segel_z1_2, model.Dhow, model.mast_2);
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.segel_z2_2, model.Dhow, model.mast_2);
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.segel_z3_2, model.Dhow, model.mast_2);
+        renderPart(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha, model.segel_z4_2, model.Dhow, model.mast_2);
+    }
+
+    private void renderPart(MatrixStack matrixStack, IVertexBuilder buffer, int packedLight, int packedOverlay, float red, float green, float blue, float alpha, ModelRenderer part, ModelRenderer... parents) {
+        if (!part.visible) {
+            return;
+        }
+        matrixStack.pushPose();
+        for (ModelRenderer parent : parents) {
+            parent.translateAndRotate(matrixStack);
+        }
+        part.render(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha);
+        matrixStack.popPose();
+    }
+}

--- a/src/main/java/com/talhanation/smallships/client/model/ModelDrakkar.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelDrakkar.java
@@ -714,9 +714,27 @@ public class ModelDrakkar extends EntityModel<AbstractBannerUser> {
 
    @Override
    public void renderToBuffer(MatrixStack matrixStackIn, IVertexBuilder bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
+      boolean sail0 = this.Sail_z0.visible;
+      boolean sail1 = this.Sail_z1.visible;
+      boolean sail2 = this.Sail_z2.visible;
+      boolean sail3 = this.Sail_z3.visible;
+      boolean sail4 = this.Sail_z4.visible;
+
+      this.Sail_z0.visible = false;
+      this.Sail_z1.visible = false;
+      this.Sail_z2.visible = false;
+      this.Sail_z3.visible = false;
+      this.Sail_z4.visible = false;
+
       ImmutableList.of(this.botom_1).forEach((modelRenderer) -> {
          modelRenderer.render(matrixStackIn, bufferIn, packedLightIn, packedOverlayIn, red, green, blue, alpha);
       });
+
+      this.Sail_z0.visible = sail0;
+      this.Sail_z1.visible = sail1;
+      this.Sail_z2.visible = sail2;
+      this.Sail_z3.visible = sail3;
+      this.Sail_z4.visible = sail4;
    }
 
    @Override

--- a/src/main/java/com/talhanation/smallships/client/model/ModelDrakkarSail.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelDrakkarSail.java
@@ -1,0 +1,50 @@
+package com.talhanation.smallships.client.model;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.vertex.IVertexBuilder;
+import com.talhanation.smallships.entities.AbstractBannerUser;
+import com.talhanation.smallships.entities.AbstractSailShip;
+import net.minecraft.client.renderer.model.ModelRenderer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+import java.util.List;
+
+@OnlyIn(Dist.CLIENT)
+public class ModelDrakkarSail extends ModelSail {
+
+    private final ModelDrakkar model;
+    private final List<ModelRenderer> sailStates;
+
+    public ModelDrakkarSail() {
+        this.model = new ModelDrakkar();
+        this.sailStates = ImmutableList.of(
+                model.Sail_z0,
+                model.Sail_z1,
+                model.Sail_z2,
+                model.Sail_z3,
+                model.Sail_z4
+        );
+    }
+
+    @Override
+    public void setupAnim(AbstractSailShip entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch) {
+        if (entity instanceof AbstractBannerUser) {
+            model.setupAnim((AbstractBannerUser) entity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
+        }
+    }
+
+    @Override
+    public void renderToBuffer(MatrixStack matrixStack, IVertexBuilder buffer, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
+        matrixStack.pushPose();
+        model.botom_1.translateAndRotate(matrixStack);
+        model.Mast_1.translateAndRotate(matrixStack);
+        for (ModelRenderer sail : sailStates) {
+            if (sail.visible) {
+                sail.render(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha);
+            }
+        }
+        matrixStack.popPose();
+    }
+}

--- a/src/main/java/com/talhanation/smallships/client/model/ModelGalley.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelGalley.java
@@ -1115,9 +1115,27 @@ public class ModelGalley extends EntityModel<AbstractBannerUser> {
 
    @Override
    public void renderToBuffer(MatrixStack matrixStackIn, IVertexBuilder bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
+      boolean segel0 = this.Segel_z0.visible;
+      boolean segel1 = this.Segel_z1.visible;
+      boolean segel2 = this.Segel_z2.visible;
+      boolean segel3 = this.Segel_z3.visible;
+      boolean segel4 = this.Segel_z4.visible;
+
+      this.Segel_z0.visible = false;
+      this.Segel_z1.visible = false;
+      this.Segel_z2.visible = false;
+      this.Segel_z3.visible = false;
+      this.Segel_z4.visible = false;
+
       ImmutableList.of(this.botom_1).forEach((modelRenderer) -> {
          modelRenderer.render(matrixStackIn, bufferIn, packedLightIn, packedOverlayIn, red, green, blue, alpha);
       });
+
+      this.Segel_z0.visible = segel0;
+      this.Segel_z1.visible = segel1;
+      this.Segel_z2.visible = segel2;
+      this.Segel_z3.visible = segel3;
+      this.Segel_z4.visible = segel4;
    }
 
    @Override

--- a/src/main/java/com/talhanation/smallships/client/model/ModelGalleySail.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelGalleySail.java
@@ -1,0 +1,50 @@
+package com.talhanation.smallships.client.model;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.vertex.IVertexBuilder;
+import com.talhanation.smallships.entities.AbstractBannerUser;
+import com.talhanation.smallships.entities.AbstractSailShip;
+import net.minecraft.client.renderer.model.ModelRenderer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+import java.util.List;
+
+@OnlyIn(Dist.CLIENT)
+public class ModelGalleySail extends ModelSail {
+
+    private final ModelGalley model;
+    private final List<ModelRenderer> sailStates;
+
+    public ModelGalleySail() {
+        this.model = new ModelGalley();
+        this.sailStates = ImmutableList.of(
+                model.Segel_z0,
+                model.Segel_z1,
+                model.Segel_z2,
+                model.Segel_z3,
+                model.Segel_z4
+        );
+    }
+
+    @Override
+    public void setupAnim(AbstractSailShip entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch) {
+        if (entity instanceof AbstractBannerUser) {
+            model.setupAnim((AbstractBannerUser) entity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
+        }
+    }
+
+    @Override
+    public void renderToBuffer(MatrixStack matrixStack, IVertexBuilder buffer, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
+        matrixStack.pushPose();
+        model.botom_1.translateAndRotate(matrixStack);
+        model.Mast_oben.translateAndRotate(matrixStack);
+        for (ModelRenderer sail : sailStates) {
+            if (sail.visible) {
+                sail.render(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha);
+            }
+        }
+        matrixStack.popPose();
+    }
+}

--- a/src/main/java/com/talhanation/smallships/client/model/ModelWarGalley.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelWarGalley.java
@@ -1928,9 +1928,42 @@ public class ModelWarGalley extends EntityModel<AbstractBannerUser> {
 
    @Override
    public void renderToBuffer(MatrixStack matrixStackIn, IVertexBuilder bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
+      boolean segel1_0 = this.Segel_1_z0.visible;
+      boolean segel1_1 = this.Segel_1_z1.visible;
+      boolean segel1_2 = this.Segel_1_z2.visible;
+      boolean segel1_3 = this.Segel_1_z3.visible;
+      boolean segel1_4 = this.Segel_1_z4.visible;
+      boolean segel2_0 = this.Segel_2_z0.visible;
+      boolean segel2_1 = this.Segel_2_z1.visible;
+      boolean segel2_2 = this.Segel_2_z2.visible;
+      boolean segel2_3 = this.Segel_2_z3.visible;
+      boolean segel2_4 = this.Segel_2_z4.visible;
+
+      this.Segel_1_z0.visible = false;
+      this.Segel_1_z1.visible = false;
+      this.Segel_1_z2.visible = false;
+      this.Segel_1_z3.visible = false;
+      this.Segel_1_z4.visible = false;
+      this.Segel_2_z0.visible = false;
+      this.Segel_2_z1.visible = false;
+      this.Segel_2_z2.visible = false;
+      this.Segel_2_z3.visible = false;
+      this.Segel_2_z4.visible = false;
+
       ImmutableList.of(this.botom_1).forEach((modelRenderer) -> {
          modelRenderer.render(matrixStackIn, bufferIn, packedLightIn, packedOverlayIn, red, green, blue, alpha);
       });
+
+      this.Segel_1_z0.visible = segel1_0;
+      this.Segel_1_z1.visible = segel1_1;
+      this.Segel_1_z2.visible = segel1_2;
+      this.Segel_1_z3.visible = segel1_3;
+      this.Segel_1_z4.visible = segel1_4;
+      this.Segel_2_z0.visible = segel2_0;
+      this.Segel_2_z1.visible = segel2_1;
+      this.Segel_2_z2.visible = segel2_2;
+      this.Segel_2_z3.visible = segel2_3;
+      this.Segel_2_z4.visible = segel2_4;
    }
 
    @Override

--- a/src/main/java/com/talhanation/smallships/client/model/ModelWarGalleySail.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelWarGalleySail.java
@@ -1,0 +1,70 @@
+package com.talhanation.smallships.client.model;
+
+import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.vertex.IVertexBuilder;
+import com.talhanation.smallships.entities.AbstractBannerUser;
+import com.talhanation.smallships.entities.AbstractSailShip;
+import net.minecraft.client.renderer.model.ModelRenderer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+import java.util.List;
+
+@OnlyIn(Dist.CLIENT)
+public class ModelWarGalleySail extends ModelSail {
+
+    private final ModelWarGalley model;
+    private final List<ModelRenderer> firstMastSails;
+    private final List<ModelRenderer> secondMastSails;
+
+    public ModelWarGalleySail() {
+        this.model = new ModelWarGalley();
+        this.firstMastSails = ImmutableList.of(
+                model.Segel_1_z0,
+                model.Segel_1_z1,
+                model.Segel_1_z2,
+                model.Segel_1_z3,
+                model.Segel_1_z4
+        );
+        this.secondMastSails = ImmutableList.of(
+                model.Segel_2_z0,
+                model.Segel_2_z1,
+                model.Segel_2_z2,
+                model.Segel_2_z3,
+                model.Segel_2_z4
+        );
+    }
+
+    @Override
+    public void setupAnim(AbstractSailShip entity, float limbSwing, float limbSwingAmount, float ageInTicks, float netHeadYaw, float headPitch) {
+        if (entity instanceof AbstractBannerUser) {
+            model.setupAnim((AbstractBannerUser) entity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw, headPitch);
+        }
+    }
+
+    @Override
+    public void renderToBuffer(MatrixStack matrixStack, IVertexBuilder buffer, int packedLight, int packedOverlay, float red, float green, float blue, float alpha) {
+        matrixStack.pushPose();
+        model.botom_1.translateAndRotate(matrixStack);
+        model.Mast_2.translateAndRotate(matrixStack);
+        model.Mast_2_oben_1.translateAndRotate(matrixStack);
+        for (ModelRenderer sail : firstMastSails) {
+            if (sail.visible) {
+                sail.render(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha);
+            }
+        }
+        matrixStack.popPose();
+
+        matrixStack.pushPose();
+        model.botom_1.translateAndRotate(matrixStack);
+        model.Mast_1.translateAndRotate(matrixStack);
+        model.Mast_2_oben.translateAndRotate(matrixStack);
+        for (ModelRenderer sail : secondMastSails) {
+            if (sail.visible) {
+                sail.render(matrixStack, buffer, packedLight, packedOverlay, red, green, blue, alpha);
+            }
+        }
+        matrixStack.popPose();
+    }
+}

--- a/src/main/java/com/talhanation/smallships/client/render/RenderEntityGalley.java
+++ b/src/main/java/com/talhanation/smallships/client/render/RenderEntityGalley.java
@@ -2,6 +2,7 @@ package com.talhanation.smallships.client.render;
 
 import com.talhanation.smallships.Main;
 import com.talhanation.smallships.client.model.ModelGalley;
+import com.talhanation.smallships.client.model.ModelGalleySail;
 import com.talhanation.smallships.entities.GalleyEntity;
 import net.minecraft.client.renderer.entity.EntityRendererManager;
 import net.minecraft.util.ResourceLocation;
@@ -19,7 +20,7 @@ public class RenderEntityGalley extends AbstractShipRenderer<GalleyEntity> {
     };
 
     public RenderEntityGalley(EntityRendererManager manager) {
-        super(manager, new ModelGalley(), null);
+        super(manager, new ModelGalley(), ModelGalleySail::new);
         this.shadowRadius = 1.4F;
     }
 
@@ -36,6 +37,11 @@ public class RenderEntityGalley extends AbstractShipRenderer<GalleyEntity> {
     @Override
     protected Vector3d getModelTranslation(GalleyEntity entity) {
         return new Vector3d(0.0D, -1.7D, -0.95D);
+    }
+
+    @Override
+    protected float getModelYawOffset(GalleyEntity entity) {
+        return -90F;
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/client/render/RenderEntityWarGalley.java
+++ b/src/main/java/com/talhanation/smallships/client/render/RenderEntityWarGalley.java
@@ -2,6 +2,7 @@ package com.talhanation.smallships.client.render;
 
 import com.talhanation.smallships.Main;
 import com.talhanation.smallships.client.model.ModelWarGalley;
+import com.talhanation.smallships.client.model.ModelWarGalleySail;
 import com.talhanation.smallships.entities.WarGalleyEntity;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.entity.EntityRendererManager;
@@ -21,7 +22,7 @@ public class RenderEntityWarGalley extends AbstractShipRenderer<WarGalleyEntity>
     };
 
     public RenderEntityWarGalley(EntityRendererManager manager) {
-        super(manager, new ModelWarGalley(), null);
+        super(manager, new ModelWarGalley(), ModelWarGalleySail::new);
         this.shadowRadius = 1.5F;
     }
 
@@ -38,6 +39,11 @@ public class RenderEntityWarGalley extends AbstractShipRenderer<WarGalleyEntity>
     @Override
     protected Vector3d getModelTranslation(WarGalleyEntity entity) {
         return new Vector3d(0.0D, -1.8D, -1.0D);
+    }
+
+    @Override
+    protected float getModelYawOffset(WarGalleyEntity entity) {
+        return -90F;
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/entities/RowBoatEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/RowBoatEntity.java
@@ -19,7 +19,7 @@ public class RowBoatEntity extends AbstractBasicShip {
 
     public RowBoatEntity(EntityType<? extends RowBoatEntity> type, World world) {
         super(type, world);
-        this.setSailState(1);
+        this.setSailState(0);
     }
 
     public RowBoatEntity(World world, double x, double y, double z) {


### PR DESCRIPTION
## Summary
- register the dhow, drakkar, galley and war galley with dedicated sail models so their sails render through the existing dyeable system
- hide sail parts while drawing hull geometry to prevent double rendering and correct rowboat defaults that caused crashes
- adjust galley renderer alignment so the new hulls face forward before sails are overlaid

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65 from Groovy tooling when running on Java 21)*

------
https://chatgpt.com/codex/tasks/task_b_68d0469c9e70832ebdf49c6c8c23dc87