### PR TITLE
Initialize paddle state data parameters

### DIFF
--- a/src/main/java/com/talhanation/smallships/entities/AbstractSailShip.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractSailShip.java
@@ -79,6 +79,8 @@ public abstract class AbstractSailShip extends AbstractWaterVehicle {
         entityData.define(SAIL_STATE, 0);
         entityData.define(SAIL_COLOR, "white");
         entityData.define(TYPE, AbstractSailShip.Type.OAK.ordinal());
+        entityData.define(LEFT_PADDLE, false);
+        entityData.define(RIGHT_PADDLE, false);
     }
 
     public abstract float getMaxSpeed();


### PR DESCRIPTION
## Summary
- register the left and right paddle entity data parameters during initialization to avoid null lookups

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d04e50f814832e8b8944486d28bfe0