### PR TITLE
Align sail handling across remaining ship models

### DIFF
--- a/src/main/java/com/talhanation/smallships/client/model/ModelDhow.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelDhow.java
@@ -466,6 +466,12 @@ public class ModelDhow extends EntityModel<AbstractBannerUser> {
    public ModelRenderer segel_1_264;
    public ModelRenderer steer;
 
+   private static final float HULL_X_ROT = 1.5707964F;
+   private static final float HULL_Y_ROT = -1.5707964F;
+
+   private final ModelRenderer[] leftSailStates;
+   private final ModelRenderer[] rightSailStates;
+
    public ModelDhow() {
       this.texWidth = 128;
       this.texHeight = 64;
@@ -2455,48 +2461,27 @@ public class ModelDhow extends EntityModel<AbstractBannerUser> {
       this.Cargo0.addChild(this.Cargo_0_1);
       this.segel_1_198.addChild(this.segel_1_199);
       this.segel_2_18.addChild(this.segel_2_19);
+
+      this.leftSailStates = new ModelRenderer[]{this.Sail_z0_1, this.segel_z1_1, this.segel_z2_1, this.segel_z3_1, this.segel_z4_1};
+      this.rightSailStates = new ModelRenderer[]{this.Sail_z0_2, this.segel_z1_2, this.segel_z2_2, this.segel_z3_2, this.segel_z4_2};
    }
 
    @Override
    public void renderToBuffer(MatrixStack matrixStackIn, IVertexBuilder bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
-      boolean sail0Left = this.Sail_z0_1.visible;
-      boolean sail0Right = this.Sail_z0_2.visible;
-      boolean sail1Left = this.segel_z1_1.visible;
-      boolean sail1Right = this.segel_z1_2.visible;
-      boolean sail2Left = this.segel_z2_1.visible;
-      boolean sail2Right = this.segel_z2_2.visible;
-      boolean sail3Left = this.segel_z3_1.visible;
-      boolean sail3Right = this.segel_z3_2.visible;
-      boolean sail4Left = this.segel_z4_1.visible;
-      boolean sail4Right = this.segel_z4_2.visible;
+      boolean[] leftVisibility = captureVisibility(this.leftSailStates);
+      boolean[] rightVisibility = captureVisibility(this.rightSailStates);
       boolean rope = this.seil_0.visible;
 
-      this.Sail_z0_1.visible = false;
-      this.Sail_z0_2.visible = false;
-      this.segel_z1_1.visible = false;
-      this.segel_z1_2.visible = false;
-      this.segel_z2_1.visible = false;
-      this.segel_z2_2.visible = false;
-      this.segel_z3_1.visible = false;
-      this.segel_z3_2.visible = false;
-      this.segel_z4_1.visible = false;
-      this.segel_z4_2.visible = false;
+      setVisibility(this.leftSailStates, false);
+      setVisibility(this.rightSailStates, false);
       this.seil_0.visible = false;
 
       ImmutableList.of(this.Dhow).forEach((modelRenderer) -> {
          modelRenderer.render(matrixStackIn, bufferIn, packedLightIn, packedOverlayIn, red, green, blue, alpha);
       });
 
-      this.Sail_z0_1.visible = sail0Left;
-      this.Sail_z0_2.visible = sail0Right;
-      this.segel_z1_1.visible = sail1Left;
-      this.segel_z1_2.visible = sail1Right;
-      this.segel_z2_1.visible = sail2Left;
-      this.segel_z2_2.visible = sail2Right;
-      this.segel_z3_1.visible = sail3Left;
-      this.segel_z3_2.visible = sail3Right;
-      this.segel_z4_1.visible = sail4Left;
-      this.segel_z4_2.visible = sail4Right;
+      restoreVisibility(this.leftSailStates, leftVisibility);
+      restoreVisibility(this.rightSailStates, rightVisibility);
       this.seil_0.visible = rope;
    }
 
@@ -2508,87 +2493,52 @@ public class ModelDhow extends EntityModel<AbstractBannerUser> {
 
       DhowEntity dhow = (DhowEntity) entityIn;
 
-      int state = dhow.getSailState();
-      switch(state) {
-      case 0:
-         this.seil_0.visible = false;
-         this.segel_z4_1.visible = false;
-         this.segel_z4_2.visible = false;
-         this.segel_z3_1.visible = false;
-         this.segel_z3_2.visible = false;
-         this.segel_z2_1.visible = false;
-         this.segel_z2_2.visible = false;
-         this.segel_z1_1.visible = false;
-         this.segel_z1_2.visible = false;
-         this.Sail_z0_1.visible = true;
-         this.Sail_z0_2.visible = true;
-         break;
-      case 1:
-         this.seil_0.visible = false;
-         this.segel_z4_1.visible = false;
-         this.segel_z4_2.visible = false;
-         this.segel_z3_1.visible = false;
-         this.segel_z3_2.visible = false;
-         this.segel_z2_1.visible = false;
-         this.segel_z2_2.visible = false;
-         this.Sail_z0_1.visible = false;
-         this.Sail_z0_2.visible = false;
-         this.segel_z1_1.visible = true;
-         this.segel_z1_2.visible = true;
-         break;
-      case 2:
-         this.seil_0.visible = false;
-         this.segel_z4_1.visible = false;
-         this.segel_z4_2.visible = false;
-         this.segel_z3_1.visible = false;
-         this.segel_z3_2.visible = false;
-         this.segel_z1_1.visible = false;
-         this.segel_z1_2.visible = false;
-         this.Sail_z0_1.visible = false;
-         this.Sail_z0_2.visible = false;
-         this.segel_z2_1.visible = true;
-         this.segel_z2_2.visible = true;
-         break;
-      case 3:
-         this.seil_0.visible = false;
-         this.segel_z4_1.visible = false;
-         this.segel_z4_2.visible = false;
-         this.segel_z2_1.visible = false;
-         this.segel_z2_2.visible = false;
-         this.segel_z1_1.visible = false;
-         this.segel_z1_2.visible = false;
-         this.Sail_z0_1.visible = false;
-         this.Sail_z0_2.visible = false;
-         this.segel_z3_1.visible = true;
-         this.segel_z3_2.visible = true;
-         break;
-      case 4:
-         this.segel_z3_1.visible = false;
-         this.segel_z3_2.visible = false;
-         this.segel_z2_1.visible = false;
-         this.segel_z2_2.visible = false;
-         this.segel_z1_1.visible = false;
-         this.segel_z1_2.visible = false;
-         this.Sail_z0_1.visible = false;
-         this.Sail_z0_2.visible = false;
-         this.seil_0.visible = true;
-         this.segel_z4_1.visible = true;
-         this.segel_z4_2.visible = true;
-      }
+      this.Dhow.xRot = HULL_X_ROT;
+      this.Dhow.yRot = HULL_Y_ROT;
+      this.Dhow.zRot = 0.0F;
 
-      if (dhow.getSteerState(0)) {
-         this.steer.xRot = MathHelper.cos(3.1415927F);
-      } else if (dhow.getSteerState(1)) {
-         this.steer.xRot = -MathHelper.cos(3.1415927F);
-      } else {
-         this.steer.xRot = 0.0F;
-      }
+      int state = MathHelper.clamp(dhow.getSailState(), 0, this.leftSailStates.length - 1);
+      updateSailState(state, this.leftSailStates);
+      updateSailState(state, this.rightSailStates);
+      this.seil_0.visible = state == this.leftSailStates.length - 1;
+
+      float steerAngle = -dhow.getRotSpeed();
+      this.steer.xRot = 0.0F;
+      this.steer.yRot = steerAngle;
+      this.steer.zRot = 0.0F;
 
       int cargo = dhow.getCargo();
       this.Cargo0.visible = cargo >= 1;
       this.Cargo1.visible = cargo >= 2;
       this.Cargo2.visible = cargo >= 3;
       this.Cargo3.visible = cargo >= 4;
+   }
+
+   private static boolean[] captureVisibility(ModelRenderer[] sails) {
+      boolean[] visibility = new boolean[sails.length];
+      for (int i = 0; i < sails.length; ++i) {
+         visibility[i] = sails[i].visible;
+      }
+      return visibility;
+   }
+
+   private static void setVisibility(ModelRenderer[] sails, boolean visible) {
+      for (ModelRenderer sail : sails) {
+         sail.visible = visible;
+      }
+   }
+
+   private static void restoreVisibility(ModelRenderer[] sails, boolean[] visibility) {
+      for (int i = 0; i < sails.length; ++i) {
+         sails[i].visible = visibility[i];
+      }
+   }
+
+   private static void updateSailState(int state, ModelRenderer[] sails) {
+      int clamped = MathHelper.clamp(state, 0, sails.length - 1);
+      for (int i = 0; i < sails.length; ++i) {
+         sails[i].visible = i == clamped;
+      }
    }
 
    public void setRotateAngle(ModelRenderer modelRenderer, float x, float y, float z) {

--- a/src/main/java/com/talhanation/smallships/client/model/ModelDrakkar.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelDrakkar.java
@@ -94,6 +94,16 @@ public class ModelDrakkar extends EntityModel<AbstractBannerUser> {
    public ModelRenderer part1_4;
    public ModelRenderer part25_1;
 
+   private static final float HULL_Y_ROT = ((float)Math.PI / 2F);
+   private static final float PADDLE_MIN_X_ROT = -1.0471975803375244F;
+   private static final float PADDLE_MAX_X_ROT = -0.2617993950843811F;
+   private static final float PADDLE_MIN_Y_ROT = -0.7853981852531433F;
+   private static final float PADDLE_MAX_Y_ROT = 0.7853981852531433F;
+
+   private final ModelRenderer[] leftPaddles;
+   private final ModelRenderer[] rightPaddles;
+   private final ModelRenderer[] sailStates;
+
    public ModelDrakkar() {
       this.texWidth = 128;
       this.texHeight = 64;
@@ -710,31 +720,23 @@ public class ModelDrakkar extends EntityModel<AbstractBannerUser> {
       this.Sail_z4.addChild(this.Sail_1_2);
       this.botom_1.addChild(this.ruder_r_1);
       this.part2.addChild(this.part1_3);
+
+      this.rightPaddles = new ModelRenderer[]{this.ruder_r_1, this.ruder_r_2, this.ruder_r_3, this.ruder_r_4};
+      this.leftPaddles = new ModelRenderer[]{this.ruder_l_1, this.ruder_l_2, this.ruder_l_3, this.ruder_l_4};
+      this.sailStates = new ModelRenderer[]{this.Sail_z0, this.Sail_z1, this.Sail_z2, this.Sail_z3, this.Sail_z4};
    }
 
    @Override
    public void renderToBuffer(MatrixStack matrixStackIn, IVertexBuilder bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
-      boolean sail0 = this.Sail_z0.visible;
-      boolean sail1 = this.Sail_z1.visible;
-      boolean sail2 = this.Sail_z2.visible;
-      boolean sail3 = this.Sail_z3.visible;
-      boolean sail4 = this.Sail_z4.visible;
+      boolean[] visibility = captureVisibility(this.sailStates);
 
-      this.Sail_z0.visible = false;
-      this.Sail_z1.visible = false;
-      this.Sail_z2.visible = false;
-      this.Sail_z3.visible = false;
-      this.Sail_z4.visible = false;
+      setVisibility(this.sailStates, false);
 
       ImmutableList.of(this.botom_1).forEach((modelRenderer) -> {
          modelRenderer.render(matrixStackIn, bufferIn, packedLightIn, packedOverlayIn, red, green, blue, alpha);
       });
 
-      this.Sail_z0.visible = sail0;
-      this.Sail_z1.visible = sail1;
-      this.Sail_z2.visible = sail2;
-      this.Sail_z3.visible = sail3;
-      this.Sail_z4.visible = sail4;
+      restoreVisibility(this.sailStates, visibility);
    }
 
    @Override
@@ -745,49 +747,18 @@ public class ModelDrakkar extends EntityModel<AbstractBannerUser> {
 
       DrakkarEntity drakkar = (DrakkarEntity) entityIn;
 
+      this.botom_1.xRot = 0.0F;
+      this.botom_1.yRot = HULL_Y_ROT;
+      this.botom_1.zRot = 0.0F;
+
       int state = drakkar.getSailState();
-      switch(state) {
-      case 0:
-         this.Sail_z0.visible = true;
-         this.Sail_z1.visible = false;
-         this.Sail_z2.visible = false;
-         this.Sail_z3.visible = false;
-         this.Sail_z4.visible = false;
-         break;
-      case 1:
-         this.Sail_z0.visible = false;
-         this.Sail_z1.visible = true;
-         this.Sail_z2.visible = false;
-         this.Sail_z3.visible = false;
-         this.Sail_z4.visible = false;
-         break;
-      case 2:
-         this.Sail_z0.visible = false;
-         this.Sail_z1.visible = false;
-         this.Sail_z2.visible = true;
-         this.Sail_z3.visible = false;
-         this.Sail_z4.visible = false;
-         break;
-      case 3:
-         this.Sail_z0.visible = false;
-         this.Sail_z1.visible = false;
-         this.Sail_z2.visible = false;
-         this.Sail_z3.visible = true;
-         this.Sail_z4.visible = false;
-         break;
-      case 4:
-         this.Sail_z0.visible = false;
-         this.Sail_z1.visible = false;
-         this.Sail_z2.visible = false;
-         this.Sail_z3.visible = false;
-         this.Sail_z4.visible = true;
-      }
+      updateSailState(state, this.sailStates);
 
       int cargo = drakkar.getCargo();
       this.Cargo0.visible = cargo >= 1;
       this.Cargo1.visible = cargo >= 2;
-      this.paddels(drakkar, 0, limbSwing);
-      this.paddels(drakkar, 1, limbSwing);
+      animatePaddles(drakkar, 0, limbSwing, this.leftPaddles, false);
+      animatePaddles(drakkar, 1, limbSwing, this.rightPaddles, true);
    }
 
    public void setRotateAngle(ModelRenderer modelRenderer, float x, float y, float z) {
@@ -796,26 +767,51 @@ public class ModelDrakkar extends EntityModel<AbstractBannerUser> {
       modelRenderer.zRot = z;
    }
 
-   protected void paddels(DrakkarEntity drakkarEntity, int side, float limbSwing) {
-      float f = drakkarEntity.getRowingTime(side, limbSwing);
-      this.ruder_r_1.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r_1.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      this.ruder_r_2.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r_2.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      this.ruder_r_3.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r_3.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      this.ruder_r_4.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r_4.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      if (side == 0) {
-         this.ruder_l_1.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l_1.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-         this.ruder_l_2.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l_2.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-         this.ruder_l_3.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l_3.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-         this.ruder_l_4.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l_4.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      }
+   private void animatePaddles(DrakkarEntity drakkarEntity, int side, float limbSwing, ModelRenderer[] paddles, boolean rightSide) {
+      float rowingTime = drakkarEntity.getRowingTime(side, limbSwing);
+      float steer = -drakkarEntity.getRotSpeed();
 
+      for (ModelRenderer paddle : paddles) {
+         setPaddleRotation(paddle, rowingTime, steer, rightSide);
+      }
+   }
+
+   private static void setPaddleRotation(ModelRenderer paddle, float rowingTime, float steer, boolean rightSide) {
+      float xRot = (float)MathHelper.clamp(PADDLE_MIN_X_ROT, PADDLE_MAX_X_ROT, (double)((MathHelper.sin(-rowingTime) + 1.0F) / 2.0F));
+      float yawOffset = (float)MathHelper.clamp(PADDLE_MIN_Y_ROT, PADDLE_MAX_Y_ROT, (double)((MathHelper.sin(-rowingTime + 1.0F) + 1.0F) / 2.0F));
+      if (rightSide) {
+         paddle.xRot = xRot;
+         paddle.yRot = (float)Math.PI - yawOffset + steer;
+      } else {
+         paddle.xRot = xRot;
+         paddle.yRot = yawOffset - steer;
+      }
+   }
+
+   private static boolean[] captureVisibility(ModelRenderer[] sails) {
+      boolean[] visibility = new boolean[sails.length];
+      for (int i = 0; i < sails.length; ++i) {
+         visibility[i] = sails[i].visible;
+      }
+      return visibility;
+   }
+
+   private static void setVisibility(ModelRenderer[] sails, boolean visible) {
+      for (ModelRenderer sail : sails) {
+         sail.visible = visible;
+      }
+   }
+
+   private static void restoreVisibility(ModelRenderer[] sails, boolean[] visibility) {
+      for (int i = 0; i < sails.length; ++i) {
+         sails[i].visible = visibility[i];
+      }
+   }
+
+   private static void updateSailState(int state, ModelRenderer[] sails) {
+      int clamped = MathHelper.clamp(state, 0, sails.length - 1);
+      for (int i = 0; i < sails.length; ++i) {
+         sails[i].visible = i == clamped;
+      }
    }
 }

--- a/src/main/java/com/talhanation/smallships/client/model/ModelRowBoat.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelRowBoat.java
@@ -21,6 +21,21 @@ public class ModelRowBoat extends EntityModel<AbstractBannerUser> {
    public ModelRenderer ruder_r;
    public ModelRenderer ruder0_2;
 
+   private static final float RUDER0_1_BASE_X_ROT = 0.71279246F;
+   private static final float RUDER0_1_BASE_Y_ROT = 0.2645919F;
+   private static final float RUDER0_1_BASE_Z_ROT = 1.6029103F;
+   private static final float RUDER0_2_BASE_X_ROT = 0.05235988F;
+   private static final float RUDER0_2_BASE_Y_ROT = 0.12217305F;
+   private static final float RUDER0_2_BASE_Z_ROT = -0.4537856F;
+
+   private static final float PADDLE_MIN_X_ROT = -1.0471975803375244F;
+   private static final float PADDLE_MAX_X_ROT = -0.2617993950843811F;
+   private static final float PADDLE_MIN_Y_ROT = -0.7853981852531433F;
+   private static final float PADDLE_MAX_Y_ROT = 0.7853981852531433F;
+
+   private final ModelRenderer[] leftPaddles;
+   private final ModelRenderer[] rightPaddles;
+
    public ModelRowBoat() {
       this.texWidth = 128;
       this.texHeight = 64;
@@ -93,6 +108,9 @@ public class ModelRowBoat extends EntityModel<AbstractBannerUser> {
       this.RowBoat.addChild(this.Cargo_0);
       this.RowBoat.addChild(this.ruder0_1);
       this.RowBoat.addChild(this.ruder_l);
+
+      this.rightPaddles = new ModelRenderer[]{this.ruder_r};
+      this.leftPaddles = new ModelRenderer[]{this.ruder_l};
    }
 
    @Override
@@ -110,6 +128,19 @@ public class ModelRowBoat extends EntityModel<AbstractBannerUser> {
 
       RowBoatEntity rowBoat = (RowBoatEntity) entityIn;
 
+      float steer = -rowBoat.getRotSpeed();
+
+      this.RowBoat.xRot = 0.0F;
+      this.RowBoat.yRot = 1.5707964F;
+      this.RowBoat.zRot = 0.0F;
+
+      this.ruder0_1.xRot = RUDER0_1_BASE_X_ROT;
+      this.ruder0_1.yRot = RUDER0_1_BASE_Y_ROT + steer;
+      this.ruder0_1.zRot = RUDER0_1_BASE_Z_ROT;
+      this.ruder0_2.xRot = RUDER0_2_BASE_X_ROT;
+      this.ruder0_2.yRot = RUDER0_2_BASE_Y_ROT;
+      this.ruder0_2.zRot = RUDER0_2_BASE_Z_ROT;
+
       if (!rowBoat.isPassenger()) {
          this.ruder0_1.visible = true;
          this.ruder0_2.visible = true;
@@ -125,8 +156,8 @@ public class ModelRowBoat extends EntityModel<AbstractBannerUser> {
       int cargo = rowBoat.getCargo();
       this.Cargo_1.visible = cargo >= 1;
       this.Cargo_0.visible = cargo >= 2;
-      this.paddels(rowBoat, 0, limbSwing);
-      this.paddels(rowBoat, 1, limbSwing);
+      animatePaddles(rowBoat, 0, limbSwing, this.leftPaddles, false);
+      animatePaddles(rowBoat, 1, limbSwing, this.rightPaddles, true);
    }
 
    public void setRotateAngle(ModelRenderer modelRenderer, float x, float y, float z) {
@@ -135,14 +166,24 @@ public class ModelRowBoat extends EntityModel<AbstractBannerUser> {
       modelRenderer.zRot = z;
    }
 
-   protected void paddels(RowBoatEntity galleyEntity, int side, float limbSwing) {
-      float f = galleyEntity.getRowingTime(side, limbSwing);
-      this.ruder_r.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      if (side == 0) {
-         this.ruder_l.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      }
+   private void animatePaddles(RowBoatEntity galleyEntity, int side, float limbSwing, ModelRenderer[] paddles, boolean rightSide) {
+      float rowingTime = galleyEntity.getRowingTime(side, limbSwing);
+      float steer = -galleyEntity.getRotSpeed();
 
+      for (ModelRenderer paddle : paddles) {
+         setPaddleRotation(paddle, rowingTime, steer, rightSide);
+      }
+   }
+
+   private static void setPaddleRotation(ModelRenderer paddle, float rowingTime, float steer, boolean rightSide) {
+      float xRot = (float)MathHelper.clamp(PADDLE_MIN_X_ROT, PADDLE_MAX_X_ROT, (double)((MathHelper.sin(-rowingTime) + 1.0F) / 2.0F));
+      float yawOffset = (float)MathHelper.clamp(PADDLE_MIN_Y_ROT, PADDLE_MAX_Y_ROT, (double)((MathHelper.sin(-rowingTime + 1.0F) + 1.0F) / 2.0F));
+      if (rightSide) {
+         paddle.xRot = xRot;
+         paddle.yRot = (float)Math.PI - yawOffset + steer;
+      } else {
+         paddle.xRot = xRot;
+         paddle.yRot = yawOffset - steer;
+      }
    }
 }

--- a/src/main/java/com/talhanation/smallships/client/model/ModelWarGalley.java
+++ b/src/main/java/com/talhanation/smallships/client/model/ModelWarGalley.java
@@ -179,6 +179,17 @@ public class ModelWarGalley extends EntityModel<AbstractBannerUser> {
    public ModelRenderer Segel_1_5_7;
    public ModelRenderer Segel_1_13_7;
 
+   private static final float HULL_Y_ROT = ((float)Math.PI / 2F);
+   private static final float PADDLE_MIN_X_ROT = -1.0471975803375244F;
+   private static final float PADDLE_MAX_X_ROT = -0.2617993950843811F;
+   private static final float PADDLE_MIN_Y_ROT = -0.7853981852531433F;
+   private static final float PADDLE_MAX_Y_ROT = 0.7853981852531433F;
+
+   private final ModelRenderer[] leftPaddles;
+   private final ModelRenderer[] rightPaddles;
+   private final ModelRenderer[] firstMastSailStates;
+   private final ModelRenderer[] secondMastSailStates;
+
    public ModelWarGalley() {
       this.texWidth = 128;
       this.texHeight = 64;
@@ -1924,46 +1935,27 @@ public class ModelWarGalley extends EntityModel<AbstractBannerUser> {
       this.Mast_2_oben_1.addChild(this.Segel_1_z2);
       this.Segel_1_5.addChild(this.Segel_1_6);
       this.botom_1.addChild(this.botom_5_4);
+
+      this.rightPaddles = new ModelRenderer[]{this.ruder_r_1, this.ruder_r_2, this.ruder_r_3, this.ruder_r_4, this.ruder_r_5, this.ruder_r_6};
+      this.leftPaddles = new ModelRenderer[]{this.ruder_l_1, this.ruder_l_2, this.ruder_l_3, this.ruder_l_4, this.ruder_l_5, this.ruder_l_6};
+      this.firstMastSailStates = new ModelRenderer[]{this.Segel_1_z0, this.Segel_1_z1, this.Segel_1_z2, this.Segel_1_z3, this.Segel_1_z4};
+      this.secondMastSailStates = new ModelRenderer[]{this.Segel_2_z0, this.Segel_2_z1, this.Segel_2_z2, this.Segel_2_z3, this.Segel_2_z4};
    }
 
    @Override
    public void renderToBuffer(MatrixStack matrixStackIn, IVertexBuilder bufferIn, int packedLightIn, int packedOverlayIn, float red, float green, float blue, float alpha) {
-      boolean segel1_0 = this.Segel_1_z0.visible;
-      boolean segel1_1 = this.Segel_1_z1.visible;
-      boolean segel1_2 = this.Segel_1_z2.visible;
-      boolean segel1_3 = this.Segel_1_z3.visible;
-      boolean segel1_4 = this.Segel_1_z4.visible;
-      boolean segel2_0 = this.Segel_2_z0.visible;
-      boolean segel2_1 = this.Segel_2_z1.visible;
-      boolean segel2_2 = this.Segel_2_z2.visible;
-      boolean segel2_3 = this.Segel_2_z3.visible;
-      boolean segel2_4 = this.Segel_2_z4.visible;
+      boolean[] firstVisibility = captureVisibility(this.firstMastSailStates);
+      boolean[] secondVisibility = captureVisibility(this.secondMastSailStates);
 
-      this.Segel_1_z0.visible = false;
-      this.Segel_1_z1.visible = false;
-      this.Segel_1_z2.visible = false;
-      this.Segel_1_z3.visible = false;
-      this.Segel_1_z4.visible = false;
-      this.Segel_2_z0.visible = false;
-      this.Segel_2_z1.visible = false;
-      this.Segel_2_z2.visible = false;
-      this.Segel_2_z3.visible = false;
-      this.Segel_2_z4.visible = false;
+      setVisibility(this.firstMastSailStates, false);
+      setVisibility(this.secondMastSailStates, false);
 
       ImmutableList.of(this.botom_1).forEach((modelRenderer) -> {
          modelRenderer.render(matrixStackIn, bufferIn, packedLightIn, packedOverlayIn, red, green, blue, alpha);
       });
 
-      this.Segel_1_z0.visible = segel1_0;
-      this.Segel_1_z1.visible = segel1_1;
-      this.Segel_1_z2.visible = segel1_2;
-      this.Segel_1_z3.visible = segel1_3;
-      this.Segel_1_z4.visible = segel1_4;
-      this.Segel_2_z0.visible = segel2_0;
-      this.Segel_2_z1.visible = segel2_1;
-      this.Segel_2_z2.visible = segel2_2;
-      this.Segel_2_z3.visible = segel2_3;
-      this.Segel_2_z4.visible = segel2_4;
+      restoreVisibility(this.firstMastSailStates, firstVisibility);
+      restoreVisibility(this.secondMastSailStates, secondVisibility);
    }
 
    @Override
@@ -1974,74 +1966,19 @@ public class ModelWarGalley extends EntityModel<AbstractBannerUser> {
 
       WarGalleyEntity warGalley = (WarGalleyEntity) entityIn;
 
+      this.botom_1.xRot = 0.0F;
+      this.botom_1.yRot = HULL_Y_ROT;
+      this.botom_1.zRot = 0.0F;
+
       int state = warGalley.getSailState();
-      switch(state) {
-      case 0:
-         this.Segel_1_z0.visible = true;
-         this.Segel_1_z1.visible = false;
-         this.Segel_1_z2.visible = false;
-         this.Segel_1_z3.visible = false;
-         this.Segel_1_z4.visible = false;
-         this.Segel_2_z0.visible = true;
-         this.Segel_2_z1.visible = false;
-         this.Segel_2_z2.visible = false;
-         this.Segel_2_z3.visible = false;
-         this.Segel_2_z4.visible = false;
-         break;
-      case 1:
-         this.Segel_1_z0.visible = false;
-         this.Segel_1_z1.visible = true;
-         this.Segel_1_z2.visible = false;
-         this.Segel_1_z3.visible = false;
-         this.Segel_1_z4.visible = false;
-         this.Segel_2_z0.visible = false;
-         this.Segel_2_z1.visible = true;
-         this.Segel_2_z2.visible = false;
-         this.Segel_2_z3.visible = false;
-         this.Segel_2_z4.visible = false;
-         break;
-      case 2:
-         this.Segel_1_z0.visible = false;
-         this.Segel_1_z1.visible = false;
-         this.Segel_1_z2.visible = true;
-         this.Segel_1_z3.visible = false;
-         this.Segel_1_z4.visible = false;
-         this.Segel_2_z0.visible = false;
-         this.Segel_2_z1.visible = false;
-         this.Segel_2_z2.visible = true;
-         this.Segel_2_z3.visible = false;
-         this.Segel_2_z4.visible = false;
-         break;
-      case 3:
-         this.Segel_1_z0.visible = false;
-         this.Segel_1_z1.visible = false;
-         this.Segel_1_z2.visible = false;
-         this.Segel_1_z3.visible = true;
-         this.Segel_1_z4.visible = false;
-         this.Segel_2_z0.visible = false;
-         this.Segel_2_z1.visible = false;
-         this.Segel_2_z2.visible = false;
-         this.Segel_2_z3.visible = true;
-         this.Segel_2_z4.visible = false;
-         break;
-      case 4:
-         this.Segel_1_z0.visible = false;
-         this.Segel_1_z1.visible = false;
-         this.Segel_1_z2.visible = false;
-         this.Segel_1_z3.visible = false;
-         this.Segel_1_z4.visible = true;
-         this.Segel_2_z0.visible = false;
-         this.Segel_2_z1.visible = false;
-         this.Segel_2_z2.visible = false;
-         this.Segel_2_z3.visible = false;
-         this.Segel_2_z4.visible = true;
-      }
+      updateSailState(state, this.firstMastSailStates);
+      updateSailState(state, this.secondMastSailStates);
 
       int cargo = warGalley.getCargo();
       this.Cargo0.visible = cargo >= 1;
       this.Cargo1.visible = cargo >= 2;
-      this.paddels(warGalley, 0, limbSwing);
-      this.paddels(warGalley, 1, limbSwing);
+      animatePaddles(warGalley, 0, limbSwing, this.leftPaddles, false);
+      animatePaddles(warGalley, 1, limbSwing, this.rightPaddles, true);
    }
 
    public void setRotateAngle(ModelRenderer modelRenderer, float x, float y, float z) {
@@ -2050,34 +1987,51 @@ public class ModelWarGalley extends EntityModel<AbstractBannerUser> {
       modelRenderer.zRot = z;
    }
 
-   protected void paddels(WarGalleyEntity galleyEntity, int side, float limbSwing) {
-      float f = galleyEntity.getRowingTime(side, limbSwing);
-      this.ruder_r_1.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r_1.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      this.ruder_r_2.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r_2.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      this.ruder_r_3.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r_3.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      this.ruder_r_4.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r_4.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      this.ruder_r_5.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r_5.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      this.ruder_r_6.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-      this.ruder_r_6.yRot = 3.1415927F - (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      if (side == 0) {
-         this.ruder_l_1.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l_1.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-         this.ruder_l_2.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l_2.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-         this.ruder_l_3.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l_3.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-         this.ruder_l_4.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l_4.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-         this.ruder_l_5.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l_5.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-         this.ruder_l_6.xRot = (float)MathHelper.clamp(-1.0471975803375244D, -0.2617993950843811D, (double)((MathHelper.sin(-f) + 1.0F) / 2.0F));
-         this.ruder_l_6.yRot = (float)MathHelper.clamp(-0.7853981852531433D, 0.7853981852531433D, (double)((MathHelper.sin(-f + 1.0F) + 1.0F) / 2.0F));
-      }
+   private void animatePaddles(WarGalleyEntity galleyEntity, int side, float limbSwing, ModelRenderer[] paddles, boolean rightSide) {
+      float rowingTime = galleyEntity.getRowingTime(side, limbSwing);
+      float steer = -galleyEntity.getRotSpeed();
 
+      for (ModelRenderer paddle : paddles) {
+         setPaddleRotation(paddle, rowingTime, steer, rightSide);
+      }
+   }
+
+   private static void setPaddleRotation(ModelRenderer paddle, float rowingTime, float steer, boolean rightSide) {
+      float xRot = (float)MathHelper.clamp(PADDLE_MIN_X_ROT, PADDLE_MAX_X_ROT, (double)((MathHelper.sin(-rowingTime) + 1.0F) / 2.0F));
+      float yawOffset = (float)MathHelper.clamp(PADDLE_MIN_Y_ROT, PADDLE_MAX_Y_ROT, (double)((MathHelper.sin(-rowingTime + 1.0F) + 1.0F) / 2.0F));
+      if (rightSide) {
+         paddle.xRot = xRot;
+         paddle.yRot = (float)Math.PI - yawOffset + steer;
+      } else {
+         paddle.xRot = xRot;
+         paddle.yRot = yawOffset - steer;
+      }
+   }
+
+   private static boolean[] captureVisibility(ModelRenderer[] sails) {
+      boolean[] visibility = new boolean[sails.length];
+      for (int i = 0; i < sails.length; ++i) {
+         visibility[i] = sails[i].visible;
+      }
+      return visibility;
+   }
+
+   private static void setVisibility(ModelRenderer[] sails, boolean visible) {
+      for (ModelRenderer sail : sails) {
+         sail.visible = visible;
+      }
+   }
+
+   private static void restoreVisibility(ModelRenderer[] sails, boolean[] visibility) {
+      for (int i = 0; i < sails.length; ++i) {
+         sails[i].visible = visibility[i];
+      }
+   }
+
+   private static void updateSailState(int state, ModelRenderer[] sails) {
+      int clamped = MathHelper.clamp(state, 0, sails.length - 1);
+      for (int i = 0; i < sails.length; ++i) {
+         sails[i].visible = i == clamped;
+      }
    }
 }


### PR DESCRIPTION
## Summary
- align the war galley, galley, and drakkar models with the brig/cog helper routines so their hulls reset each frame, sails read from state arrays, and paddles steer smoothly from `getRotSpeed()`
- update the row boat model to keep its stored rudder aligned while passengers row using the shared paddle steering helpers
- simplify dhow sail visibility and tiller steering by reusing the same state capture/restore utilities and reapplying the base hull rotation every tick

## Testing
- `./gradlew check` *(fails: Gradle buildscript was compiled for class file major version 65; current JDK is too old)*

------
https://chatgpt.com/codex/tasks/task_b_68d13dc1c0a8832eb14266dd1776c8fc