### PR TITLE
Allow Dhow and Galley to mount cannons

### DIFF
--- a/src/main/java/com/talhanation/smallships/client/render/RenderEntityDhow.java
+++ b/src/main/java/com/talhanation/smallships/client/render/RenderEntityDhow.java
@@ -1,9 +1,11 @@
 package com.talhanation.smallships.client.render;
 
+import com.mojang.blaze3d.matrix.MatrixStack;
 import com.talhanation.smallships.Main;
 import com.talhanation.smallships.client.model.ModelDhow;
 import com.talhanation.smallships.client.model.ModelDhowSail;
 import com.talhanation.smallships.entities.DhowEntity;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.entity.EntityRendererManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
@@ -44,6 +46,11 @@ public class RenderEntityDhow extends AbstractShipRenderer<DhowEntity> {
     @Override
     protected float getModelYawOffset(DhowEntity entity) {
         return -90F;
+    }
+
+    @Override
+    protected void renderAdditionalParts(DhowEntity entity, float partialTicks, MatrixStack matrixStack, IRenderTypeBuffer buffer, int packedLight) {
+        entity.renderCannon(-0.65D, 0.03D, 0F, matrixStack, buffer, packedLight, partialTicks);
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/client/render/RenderEntityGalley.java
+++ b/src/main/java/com/talhanation/smallships/client/render/RenderEntityGalley.java
@@ -1,9 +1,11 @@
 package com.talhanation.smallships.client.render;
 
+import com.mojang.blaze3d.matrix.MatrixStack;
 import com.talhanation.smallships.Main;
 import com.talhanation.smallships.client.model.ModelGalley;
 import com.talhanation.smallships.client.model.ModelGalleySail;
 import com.talhanation.smallships.entities.GalleyEntity;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.entity.EntityRendererManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.vector.Vector3d;
@@ -42,6 +44,11 @@ public class RenderEntityGalley extends AbstractShipRenderer<GalleyEntity> {
     @Override
     protected float getModelYawOffset(GalleyEntity entity) {
         return -90F;
+    }
+
+    @Override
+    protected void renderAdditionalParts(GalleyEntity entity, float partialTicks, MatrixStack matrixStack, IRenderTypeBuffer buffer, int packedLight) {
+        entity.renderCannon(-0.75D, -0.55D, -90F, matrixStack, buffer, packedLight, partialTicks);
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/entities/DhowEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/DhowEntity.java
@@ -1,16 +1,27 @@
 package com.talhanation.smallships.entities;
 
+import com.talhanation.smallships.InventoryEvents;
 import com.talhanation.smallships.config.SmallShipsConfig;
 import com.talhanation.smallships.init.ModEntityTypes;
 import com.talhanation.smallships.init.ModItems;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BannerItem;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.Hand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.World;
 
-public class DhowEntity extends AbstractBasicShip {
+import java.util.List;
+
+public class DhowEntity extends AbstractCannonShip {
 
     private static final Vector3d[] PASSENGER_OFFSETS = new Vector3d[]{
             new Vector3d(-1.0D, 0.0D, 0.2D),
@@ -99,7 +110,7 @@ public class DhowEntity extends AbstractBasicShip {
 
     @Override
     public float getCannonModifier() {
-        return 0F;
+        return this.getTotalCannonCount() * 0.02F;
     }
 
     @Override
@@ -115,6 +126,11 @@ public class DhowEntity extends AbstractBasicShip {
     @Override
     public int getPassengerSize() {
         return PASSENGER_OFFSETS.length;
+    }
+
+    @Override
+    public int getMaxCannons() {
+        return 4;
     }
 
     @Override
@@ -144,5 +160,115 @@ public class DhowEntity extends AbstractBasicShip {
     @Override
     protected Item getBrokenHullItem() {
         return Items.AIR;
+    }
+
+    @Override
+    public ActionResultType interact(PlayerEntity player, Hand hand) {
+        ItemStack itemInHand = player.getItemInHand(hand);
+        if (player.isSecondaryUseActive()) {
+            if (this.getSunken()) {
+                if (!this.level.isClientSide) {
+                    ItemStack salvagedBoat = this.createShipItemStack(false);
+                    if (!salvagedBoat.isEmpty()) {
+                        if (salvagedBoat.isDamageableItem()) {
+                            salvagedBoat.setDamageValue(salvagedBoat.getMaxDamage());
+                        }
+                        ItemStack toGive = salvagedBoat.copy();
+                        if (!player.addItem(toGive)) {
+                            this.spawnAtLocation(salvagedBoat);
+                        }
+                    }
+                    setDropBrokenItemOnDestroy(false);
+                    this.destroyShip(DamageSource.GENERIC);
+                }
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
+
+            if (this.getPassengers().isEmpty()) {
+                if (!this.level.isClientSide) {
+                    setDropBrokenItemOnDestroy(false);
+                    this.spawnAtLocation(this.createShipItemStack(false));
+                    this.destroyShip(DamageSource.GENERIC);
+                }
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
+
+            if (this.isVehicle() && !(getControllingPassenger() instanceof PlayerEntity)) {
+                this.ejectPassengers();
+            } else if (!(getControllingPassenger() instanceof PlayerEntity)) {
+                InventoryEvents.openShipGUI(player, this, 0);
+            }
+
+            return ActionResultType.sidedSuccess(this.level.isClientSide);
+        }
+
+        if (!this.getSunken()) {
+            if (itemInHand.getItem() == ModItems.CANNON_ITEM.get()) {
+                this.onInteractionWithCannon(player, itemInHand);
+                return ActionResultType.SUCCESS;
+            }
+
+            if (itemInHand.getItem() instanceof BannerItem) {
+                if (!this.getHasBanner()) {
+                    this.onInteractionWithBanner(itemInHand, player);
+                    return ActionResultType.sidedSuccess(this.level.isClientSide);
+                }
+            }
+
+            if (itemInHand.getItem() == Items.SHEARS && this.getHasBanner()) {
+                this.onInteractionWithShears(player);
+                itemInHand.hurtAndBreak(1, player, living -> living.broadcastBreakEvent(hand));
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
+
+            if (!this.level.isClientSide) {
+                player.startRiding(this);
+            }
+            return ActionResultType.sidedSuccess(this.level.isClientSide);
+        }
+
+        return ActionResultType.PASS;
+    }
+
+    @Override
+    public void positionRider(Entity passenger) {
+        if (!hasPassenger(passenger)) {
+            return;
+        }
+
+        List<Entity> passengers = this.getPassengers();
+        int index = passengers.indexOf(passenger);
+        Vector3d offset = PASSENGER_OFFSETS[Math.min(index, PASSENGER_OFFSETS.length - 1)];
+        float ridingOffset = (float) ((this.removed ? 0.02D : this.getPassengersRidingOffset()) + passenger.getMyRidingOffset());
+        Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
+                .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
+        passenger.setPos(this.getX() + rotated.x, this.getY() + ridingOffset, this.getZ() + rotated.z);
+        passenger.yRot += this.deltaRotation;
+        passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
+        applyYawToEntity(passenger);
+    }
+
+    @Override
+    public void WaterSplash() {
+        Vector3d forward = this.getViewVector(0.0F);
+        float cos = MathHelper.cos(this.yRot * ((float) Math.PI / 180F)) * 0.6F;
+        float sin = MathHelper.sin(this.yRot * ((float) Math.PI / 180F)) * 0.6F;
+        for (int i = 0; i < 2; i++) {
+            this.level.addParticle(net.minecraft.particles.ParticleTypes.SPLASH,
+                    this.getX() - forward.x * 1.5D + cos,
+                    this.getY() + 0.2D,
+                    this.getZ() - forward.z * 1.5D + sin,
+                    0.0D, 0.0D, 0.0D);
+            this.level.addParticle(net.minecraft.particles.ParticleTypes.SPLASH,
+                    this.getX() - forward.x * 1.5D - cos,
+                    this.getY() + 0.2D,
+                    this.getZ() - forward.z * 1.5D - sin,
+                    0.0D, 0.0D, 0.0D);
+        }
+    }
+
+    @Override
+    public boolean getHasBanner() {
+        return false;
     }
 }

--- a/src/main/java/com/talhanation/smallships/entities/GalleyEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/GalleyEntity.java
@@ -1,16 +1,27 @@
 package com.talhanation.smallships.entities;
 
+import com.talhanation.smallships.InventoryEvents;
 import com.talhanation.smallships.config.SmallShipsConfig;
 import com.talhanation.smallships.init.ModEntityTypes;
 import com.talhanation.smallships.init.ModItems;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BannerItem;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.Hand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.World;
 
-public class GalleyEntity extends AbstractBasicShip {
+import java.util.List;
+
+public class GalleyEntity extends AbstractCannonShip {
 
     private static final Vector3d[] PASSENGER_OFFSETS = new Vector3d[]{
             new Vector3d(-1.3D, 0.0D, 0.4D),
@@ -101,7 +112,7 @@ public class GalleyEntity extends AbstractBasicShip {
 
     @Override
     public float getCannonModifier() {
-        return 0F;
+        return this.getTotalCannonCount() * 0.02F;
     }
 
     @Override
@@ -117,6 +128,11 @@ public class GalleyEntity extends AbstractBasicShip {
     @Override
     public int getPassengerSize() {
         return PASSENGER_OFFSETS.length;
+    }
+
+    @Override
+    public int getMaxCannons() {
+        return 4;
     }
 
     @Override
@@ -146,5 +162,115 @@ public class GalleyEntity extends AbstractBasicShip {
     @Override
     protected Item getBrokenHullItem() {
         return Items.AIR;
+    }
+
+    @Override
+    public ActionResultType interact(PlayerEntity player, Hand hand) {
+        ItemStack itemInHand = player.getItemInHand(hand);
+        if (player.isSecondaryUseActive()) {
+            if (this.getSunken()) {
+                if (!this.level.isClientSide) {
+                    ItemStack salvagedBoat = this.createShipItemStack(false);
+                    if (!salvagedBoat.isEmpty()) {
+                        if (salvagedBoat.isDamageableItem()) {
+                            salvagedBoat.setDamageValue(salvagedBoat.getMaxDamage());
+                        }
+                        ItemStack toGive = salvagedBoat.copy();
+                        if (!player.addItem(toGive)) {
+                            this.spawnAtLocation(salvagedBoat);
+                        }
+                    }
+                    setDropBrokenItemOnDestroy(false);
+                    this.destroyShip(DamageSource.GENERIC);
+                }
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
+
+            if (this.getPassengers().isEmpty()) {
+                if (!this.level.isClientSide) {
+                    setDropBrokenItemOnDestroy(false);
+                    this.spawnAtLocation(this.createShipItemStack(false));
+                    this.destroyShip(DamageSource.GENERIC);
+                }
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
+
+            if (this.isVehicle() && !(getControllingPassenger() instanceof PlayerEntity)) {
+                this.ejectPassengers();
+            } else if (!(getControllingPassenger() instanceof PlayerEntity)) {
+                InventoryEvents.openShipGUI(player, this, 0);
+            }
+
+            return ActionResultType.sidedSuccess(this.level.isClientSide);
+        }
+
+        if (!this.getSunken()) {
+            if (itemInHand.getItem() == ModItems.CANNON_ITEM.get()) {
+                this.onInteractionWithCannon(player, itemInHand);
+                return ActionResultType.SUCCESS;
+            }
+
+            if (itemInHand.getItem() instanceof BannerItem) {
+                if (!this.getHasBanner()) {
+                    this.onInteractionWithBanner(itemInHand, player);
+                    return ActionResultType.sidedSuccess(this.level.isClientSide);
+                }
+            }
+
+            if (itemInHand.getItem() == Items.SHEARS && this.getHasBanner()) {
+                this.onInteractionWithShears(player);
+                itemInHand.hurtAndBreak(1, player, living -> living.broadcastBreakEvent(hand));
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
+
+            if (!this.level.isClientSide) {
+                player.startRiding(this);
+            }
+            return ActionResultType.sidedSuccess(this.level.isClientSide);
+        }
+
+        return ActionResultType.PASS;
+    }
+
+    @Override
+    public void positionRider(Entity passenger) {
+        if (!hasPassenger(passenger)) {
+            return;
+        }
+
+        List<Entity> passengers = this.getPassengers();
+        int index = passengers.indexOf(passenger);
+        Vector3d offset = PASSENGER_OFFSETS[Math.min(index, PASSENGER_OFFSETS.length - 1)];
+        float ridingOffset = (float) ((this.removed ? 0.02D : this.getPassengersRidingOffset()) + passenger.getMyRidingOffset());
+        Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
+                .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
+        passenger.setPos(this.getX() + rotated.x, this.getY() + ridingOffset, this.getZ() + rotated.z);
+        passenger.yRot += this.deltaRotation;
+        passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
+        applyYawToEntity(passenger);
+    }
+
+    @Override
+    public void WaterSplash() {
+        Vector3d forward = this.getViewVector(0.0F);
+        float cos = MathHelper.cos(this.yRot * ((float) Math.PI / 180F)) * 0.6F;
+        float sin = MathHelper.sin(this.yRot * ((float) Math.PI / 180F)) * 0.6F;
+        for (int i = 0; i < 2; i++) {
+            this.level.addParticle(net.minecraft.particles.ParticleTypes.SPLASH,
+                    this.getX() - forward.x * 1.5D + cos,
+                    this.getY() + 0.2D,
+                    this.getZ() - forward.z * 1.5D + sin,
+                    0.0D, 0.0D, 0.0D);
+            this.level.addParticle(net.minecraft.particles.ParticleTypes.SPLASH,
+                    this.getX() - forward.x * 1.5D - cos,
+                    this.getY() + 0.2D,
+                    this.getZ() - forward.z * 1.5D - sin,
+                    0.0D, 0.0D, 0.0D);
+        }
+    }
+
+    @Override
+    public boolean getHasBanner() {
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- convert the Dhow and Galley entities to cannon-capable ships with four total cannons and appropriate interaction handling
- update passenger positioning and splash effects to match the new cannon ship base class
- render mounted cannons for both hulls so cannon placement is visible in game

## Testing
- ./gradlew check *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_b_68d15703a78c832ea1365ffeb85a264f