### PR TITLE
Add cannon support to small boats with configurable storage

### DIFF
--- a/src/main/java/com/talhanation/smallships/InventoryEvents.java
+++ b/src/main/java/com/talhanation/smallships/InventoryEvents.java
@@ -8,15 +8,19 @@ import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.INamedContainerProvider;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraftforge.fml.network.NetworkHooks;
 
 public class InventoryEvents {
 
     public static void openShipGUI(PlayerEntity player, AbstractInventoryEntity invEntity, int startSlot) {
-        if (startSlot == 0){
-            invEntity.setInvPage(1);
-        }
+        int maxPage = Math.max(1, invEntity.getMaxInvPage());
+        int requestedPage = startSlot / 54 + 1;
+        int clampedPage = MathHelper.clamp(requestedPage, 1, maxPage);
+        int slotOffset = (clampedPage - 1) * 54;
+        invEntity.setInvPage(clampedPage);
+
         if (player instanceof ServerPlayerEntity) {
             NetworkHooks.openGui((ServerPlayerEntity) player, new INamedContainerProvider() {
                 @Override
@@ -26,12 +30,12 @@ public class InventoryEvents {
 
                 @Override
                 public Container createMenu(int i, PlayerInventory playerInventory, PlayerEntity playerEntity) {
-                    return new BasicShipContainer(i, invEntity, playerInventory, startSlot);
+                    return new BasicShipContainer(i, invEntity, playerInventory, slotOffset);
                 }
             }, packetBuffer -> {packetBuffer.writeUUID(invEntity.getUUID());
             });
         } else {
-            Main.SIMPLE_CHANNEL.sendToServer(new MessageOpenGui(player, invEntity, startSlot));
+            Main.SIMPLE_CHANNEL.sendToServer(new MessageOpenGui(player, invEntity, slotOffset));
         }
     }
 

--- a/src/main/java/com/talhanation/smallships/client/gui/BasicShipInvScreen.java
+++ b/src/main/java/com/talhanation/smallships/client/gui/BasicShipInvScreen.java
@@ -11,6 +11,7 @@ import de.maxhenkel.corelib.inventory.ScreenBase;
 import net.minecraft.client.gui.widget.button.Button;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 
@@ -40,17 +41,19 @@ public class BasicShipInvScreen extends ScreenBase<BasicShipContainer> {
 
         if (ship.getMaxInvPage() > 1 && ship.getInvPage() > 1){
             addButton(new Button(zeroLeftPos - 205, zeroTopPos, 40, 20, new StringTextComponent("<-"), button -> {
-
-                Main.SIMPLE_CHANNEL.sendToServer(new MessageOpenGui(playerInventory.player, ship, 0));
-                ship.setInvPage(ship.getInvPage() - 1);
+                int targetPage = MathHelper.clamp(ship.getInvPage() - 1, 1, ship.getMaxInvPage());
+                ship.setInvPage(targetPage);
+                int startSlot = (targetPage - 1) * 54;
+                Main.SIMPLE_CHANNEL.sendToServer(new MessageOpenGui(playerInventory.player, ship, startSlot));
             }));
         }
 
         if(ship.getMaxInvPage() > 1 && ship.getInvPage() < ship.getMaxInvPage()){
             addButton(new Button(zeroLeftPos + 20, zeroTopPos, 40, 20, new StringTextComponent("->"), button -> {
-
-                    ship.setInvPage(ship.getInvPage() + 1);
-                    Main.SIMPLE_CHANNEL.sendToServer(new MessageOpenGui(playerInventory.player, ship, 54));
+                    int targetPage = MathHelper.clamp(ship.getInvPage() + 1, 1, ship.getMaxInvPage());
+                    ship.setInvPage(targetPage);
+                    int startSlot = (targetPage - 1) * 54;
+                    Main.SIMPLE_CHANNEL.sendToServer(new MessageOpenGui(playerInventory.player, ship, startSlot));
             }));
         }
     }

--- a/src/main/java/com/talhanation/smallships/config/SmallShipsConfig.java
+++ b/src/main/java/com/talhanation/smallships/config/SmallShipsConfig.java
@@ -16,7 +16,7 @@ public class SmallShipsConfig {
     private static final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
     public static ForgeConfigSpec CONFIG;
     public static ForgeConfigSpec.IntValue VERSION;
-    public static final int NEW_VERSION = 10;
+    public static final int NEW_VERSION = 11;
 
     public static ForgeConfigSpec.BooleanValue PlaySwimmSound;
     public static ForgeConfigSpec.BooleanValue WaterMobFlee;
@@ -47,6 +47,34 @@ public class SmallShipsConfig {
     public static ForgeConfigSpec.DoubleValue WarGalleyHealth;
     public static ForgeConfigSpec.DoubleValue DhowHealth;
 
+    public static ForgeConfigSpec.IntValue RowBoatInventorySize;
+    public static ForgeConfigSpec.IntValue RowBoatInventoryPages;
+    public static ForgeConfigSpec.IntValue RowBoatMaxCannons;
+
+    public static ForgeConfigSpec.IntValue DrakkarInventorySize;
+    public static ForgeConfigSpec.IntValue DrakkarInventoryPages;
+    public static ForgeConfigSpec.IntValue DrakkarMaxCannons;
+
+    public static ForgeConfigSpec.IntValue GalleyInventorySize;
+    public static ForgeConfigSpec.IntValue GalleyInventoryPages;
+    public static ForgeConfigSpec.IntValue GalleyMaxCannons;
+
+    public static ForgeConfigSpec.IntValue WarGalleyInventorySize;
+    public static ForgeConfigSpec.IntValue WarGalleyInventoryPages;
+    public static ForgeConfigSpec.IntValue WarGalleyMaxCannons;
+
+    public static ForgeConfigSpec.IntValue DhowInventorySize;
+    public static ForgeConfigSpec.IntValue DhowInventoryPages;
+    public static ForgeConfigSpec.IntValue DhowMaxCannons;
+
+    public static ForgeConfigSpec.IntValue CogInventorySize;
+    public static ForgeConfigSpec.IntValue CogInventoryPages;
+    public static ForgeConfigSpec.IntValue CogMaxCannons;
+
+    public static ForgeConfigSpec.IntValue BriggInventorySize;
+    public static ForgeConfigSpec.IntValue BriggInventoryPages;
+    public static ForgeConfigSpec.IntValue BriggMaxCannons;
+
     public static ForgeConfigSpec.BooleanValue ShowShipInfo;
     public static ForgeConfigSpec.DoubleValue  ShipInfoScale;
 
@@ -70,6 +98,24 @@ public class SmallShipsConfig {
                 .worldRestart()
                 .defineInRange("GalleyTurnFactor", 0.5, 0.0, 1.0);
 
+        GalleyInventorySize = BUILDER.comment("\n" +"----Galley Inventory Size.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 36")
+                .worldRestart()
+                .defineInRange("GalleyInventorySize", 36, 0, 108);
+
+        GalleyInventoryPages = BUILDER.comment("\n" +"----Galley Inventory Pages.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 1")
+                .worldRestart()
+                .defineInRange("GalleyInventoryPages", 1, 1, 2);
+
+        GalleyMaxCannons = BUILDER.comment("\n" +"----Galley Max Cannons.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 4")
+                .worldRestart()
+                .defineInRange("GalleyMaxCannons", 4, 0, 8);
+
         CogSpeedFactor = BUILDER.comment("\n" +"----Cog Speed Factor.----" + "\n" +
                 "\t" + "(takes effect after restart)" + "\n" +
                 "\t" + "default: 1.25" )
@@ -82,6 +128,24 @@ public class SmallShipsConfig {
                 .worldRestart()
                 .defineInRange("CogTurnFactor", 0.1, 0.0, 1.0);
 
+        CogInventorySize = BUILDER.comment("\n" +"----Cog Inventory Size.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 54")
+                .worldRestart()
+                .defineInRange("CogInventorySize", 54, 0, 108);
+
+        CogInventoryPages = BUILDER.comment("\n" +"----Cog Inventory Pages.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 1")
+                .worldRestart()
+                .defineInRange("CogInventoryPages", 1, 1, 2);
+
+        CogMaxCannons = BUILDER.comment("\n" +"----Cog Max Cannons.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 4")
+                .worldRestart()
+                .defineInRange("CogMaxCannons", 4, 0, 6);
+
         WarGalleySpeedFactor = BUILDER.comment("\n" +"----War Galley Speed Factor.----" + "\n" +
                 "\t" + "(takes effect after restart)" + "\n" +
                 "\t" + "default: 1.15")
@@ -93,6 +157,24 @@ public class SmallShipsConfig {
                 "\t" + "default: 0.4")
                 .worldRestart()
                 .defineInRange("WarGalleyTurnFactor", 0.4, 0.0, 1.0);
+
+        WarGalleyInventorySize = BUILDER.comment("\n" +"----War Galley Inventory Size.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 36")
+                .worldRestart()
+                .defineInRange("WarGalleyInventorySize", 36, 0, 108);
+
+        WarGalleyInventoryPages = BUILDER.comment("\n" +"----War Galley Inventory Pages.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 1")
+                .worldRestart()
+                .defineInRange("WarGalleyInventoryPages", 1, 1, 2);
+
+        WarGalleyMaxCannons = BUILDER.comment("\n" +"----War Galley Max Cannons.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 6")
+                .worldRestart()
+                .defineInRange("WarGalleyMaxCannons", 6, 0, 10);
 
         DrakkarSpeedFactor = BUILDER.comment("\n" +"----Drakkar Speed Factor.----" + "\n" +
                 "\t" + "(takes effect after restart)" + "\n" +
@@ -113,6 +195,24 @@ public class SmallShipsConfig {
                 .worldRestart()
                 .defineInRange("DrakkarIceBreakSpeed", 2.0, 0.0, 100);
 
+        DrakkarInventorySize = BUILDER.comment("\n" +"----Drakkar Inventory Size.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 18")
+                .worldRestart()
+                .defineInRange("DrakkarInventorySize", 18, 0, 108);
+
+        DrakkarInventoryPages = BUILDER.comment("\n" +"----Drakkar Inventory Pages.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 1")
+                .worldRestart()
+                .defineInRange("DrakkarInventoryPages", 1, 1, 2);
+
+        DrakkarMaxCannons = BUILDER.comment("\n" +"----Drakkar Max Cannons.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 0")
+                .worldRestart()
+                .defineInRange("DrakkarMaxCannons", 0, 0, 6);
+
         RowBoatSpeedFactor = BUILDER.comment("\n" +"----Row Boat Speed Factor.----" + "\n" +
                 "\t" + "(takes effect after restart)" + "\n" +
                 "\t" + "default: 1.0")
@@ -124,6 +224,24 @@ public class SmallShipsConfig {
                 "\t" + "default: 0.8")
                 .worldRestart()
                 .defineInRange("RowBoatTurnFactor", 0.8, 0.0, 1.0);
+
+        RowBoatInventorySize = BUILDER.comment("\n" +"----Row Boat Inventory Size.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 9")
+                .worldRestart()
+                .defineInRange("RowBoatInventorySize", 9, 0, 108);
+
+        RowBoatInventoryPages = BUILDER.comment("\n" +"----Row Boat Inventory Pages.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 1")
+                .worldRestart()
+                .defineInRange("RowBoatInventoryPages", 1, 1, 2);
+
+        RowBoatMaxCannons = BUILDER.comment("\n" +"----Row Boat Max Cannons.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 0")
+                .worldRestart()
+                .defineInRange("RowBoatMaxCannons", 0, 0, 4);
 
         BriggSpeedFactor = BUILDER.comment("\n" +"----Brigg Speed Factor.----" + "\n" +
                 "\t" + "(takes effect after restart)" + "\n" +
@@ -137,6 +255,24 @@ public class SmallShipsConfig {
                 .worldRestart()
                 .defineInRange("BriggTurnFactor", 0.2, 0.0, 1.0);
 
+        BriggInventorySize = BUILDER.comment("\n" +"----Brigg Inventory Size.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 108")
+                .worldRestart()
+                .defineInRange("BriggInventorySize", 108, 0, 108);
+
+        BriggInventoryPages = BUILDER.comment("\n" +"----Brigg Inventory Pages.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 1")
+                .worldRestart()
+                .defineInRange("BriggInventoryPages", 1, 1, 2);
+
+        BriggMaxCannons = BUILDER.comment("\n" +"----Brigg Max Cannons.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 6")
+                .worldRestart()
+                .defineInRange("BriggMaxCannons", 6, 0, 10);
+
         DhowSpeedFactor = BUILDER.comment("\n" +"----Dhow Speed Factor.----" + "\n" +
                 "\t" + "(takes effect after restart)" + "\n" +
                 "\t" + "default: 1.35" )
@@ -148,6 +284,24 @@ public class SmallShipsConfig {
                 "\t" + "default: 0.3")
                 .worldRestart()
                 .defineInRange("DhowTurnFactor", 0.3, 0.0, 1.0);
+
+        DhowInventorySize = BUILDER.comment("\n" +"----Dhow Inventory Size.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 27")
+                .worldRestart()
+                .defineInRange("DhowInventorySize", 27, 0, 108);
+
+        DhowInventoryPages = BUILDER.comment("\n" +"----Dhow Inventory Pages.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 1")
+                .worldRestart()
+                .defineInRange("DhowInventoryPages", 1, 1, 2);
+
+        DhowMaxCannons = BUILDER.comment("\n" +"----Dhow Max Cannons.----" + "\n" +
+                "\t" + "(takes effect after restart)" + "\n" +
+                "\t" + "default: 4")
+                .worldRestart()
+                .defineInRange("DhowMaxCannons", 4, 0, 6);
 
         PlaySwimmSound = BUILDER.comment("\n" + "----Should Ships Make Swimming sounds?----" + "\n" +
                 "\t" + "(takes effect after restart)" + "\n" +

--- a/src/main/java/com/talhanation/smallships/entities/AbstractInventoryEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractInventoryEntity.java
@@ -87,10 +87,14 @@ public abstract class AbstractInventoryEntity extends AbstractSailShip {
     }
 
     public int getMaxInvPage(){
-        if(this.getInventorySize() <= 54) return 1;
-        else if (this.getInventorySize() > 54) return 2;
-        else
-            return 3;
+        int configured = Math.max(1, getConfiguredInventoryPages());
+        int size = Math.max(0, this.getInventorySize());
+        int required = Math.max(1, (size + 53) / 54);
+        return Math.max(configured, required);
+    }
+
+    public int getConfiguredInventoryPages() {
+        return 1;
     }
 
     public int getInvPage(){

--- a/src/main/java/com/talhanation/smallships/entities/BriggEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/BriggEntity.java
@@ -1,6 +1,7 @@
 package com.talhanation.smallships.entities;
 
 import com.talhanation.smallships.InventoryEvents;
+import com.talhanation.smallships.config.SmallShipsConfig;
 import com.talhanation.smallships.init.ModEntityTypes;
 import com.talhanation.smallships.init.ModItems;
 import net.minecraft.entity.Entity;
@@ -55,7 +56,12 @@ public class BriggEntity extends AbstractCannonShip{
 
     @Override
     public int getInventorySize() {
-        return 54 + 54;
+        return SmallShipsConfig.BriggInventorySize.get();
+    }
+
+    @Override
+    public int getConfiguredInventoryPages() {
+        return SmallShipsConfig.BriggInventoryPages.get();
     }
 
     @Override
@@ -128,7 +134,7 @@ public class BriggEntity extends AbstractCannonShip{
 
     @Override
     public int getMaxCannons() {
-        return 6;
+        return SmallShipsConfig.BriggMaxCannons.get();
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/entities/CogEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/CogEntity.java
@@ -1,6 +1,7 @@
 package com.talhanation.smallships.entities;
 
 import com.talhanation.smallships.InventoryEvents;
+import com.talhanation.smallships.config.SmallShipsConfig;
 import com.talhanation.smallships.init.ModEntityTypes;
 import com.talhanation.smallships.init.ModItems;
 import net.minecraft.entity.Entity;
@@ -55,7 +56,12 @@ public class CogEntity extends AbstractCannonShip{
 
     @Override
     public int getInventorySize() {
-        return 54;
+        return SmallShipsConfig.CogInventorySize.get();
+    }
+
+    @Override
+    public int getConfiguredInventoryPages() {
+        return SmallShipsConfig.CogInventoryPages.get();
     }
 
     @Override
@@ -146,7 +152,7 @@ public class CogEntity extends AbstractCannonShip{
     }
 
     public int getMaxCannons(){//max cannons
-        return 4;
+        return SmallShipsConfig.CogMaxCannons.get();
     }
 
     ////////////////////////////////////INTERACTIONS///////////////////////////////

--- a/src/main/java/com/talhanation/smallships/entities/DhowEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/DhowEntity.java
@@ -78,7 +78,12 @@ public class DhowEntity extends AbstractCannonShip {
 
     @Override
     public int getInventorySize() {
-        return 27;
+        return SmallShipsConfig.DhowInventorySize.get();
+    }
+
+    @Override
+    public int getConfiguredInventoryPages() {
+        return SmallShipsConfig.DhowInventoryPages.get();
     }
 
     @Override
@@ -139,7 +144,7 @@ public class DhowEntity extends AbstractCannonShip {
 
     @Override
     public int getMaxCannons() {
-        return 4;
+        return SmallShipsConfig.DhowMaxCannons.get();
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/entities/DrakkarEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/DrakkarEntity.java
@@ -1,16 +1,26 @@
 package com.talhanation.smallships.entities;
 
+import com.talhanation.smallships.InventoryEvents;
 import com.talhanation.smallships.config.SmallShipsConfig;
 import com.talhanation.smallships.init.ModEntityTypes;
 import com.talhanation.smallships.init.ModItems;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.Hand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.World;
 
-public class DrakkarEntity extends AbstractBasicShip {
+import java.util.List;
+
+public class DrakkarEntity extends AbstractCannonShip {
 
     private static final Vector3d[] PASSENGER_OFFSETS = new Vector3d[]{
             new Vector3d(-1.2D, 0.0D, 0.3D),
@@ -19,6 +29,32 @@ public class DrakkarEntity extends AbstractBasicShip {
             new Vector3d(0.8D, 0.0D, -0.5D),
             new Vector3d(0.0D, 0.0D, -1.2D)
     };
+    private static final Vector3d[] PASSENGER_LAYOUT_FIVE = new Vector3d[]{
+            PASSENGER_OFFSETS[0],
+            PASSENGER_OFFSETS[1],
+            PASSENGER_OFFSETS[2],
+            PASSENGER_OFFSETS[3],
+            PASSENGER_OFFSETS[4]
+    };
+    private static final Vector3d[] PASSENGER_LAYOUT_FOUR = new Vector3d[]{
+            PASSENGER_OFFSETS[0],
+            PASSENGER_OFFSETS[1],
+            PASSENGER_OFFSETS[2],
+            PASSENGER_OFFSETS[3]
+    };
+    private static final Vector3d[] PASSENGER_LAYOUT_THREE = new Vector3d[]{
+            PASSENGER_OFFSETS[0],
+            PASSENGER_OFFSETS[1],
+            PASSENGER_OFFSETS[2]
+    };
+    private static final Vector3d[] PASSENGER_LAYOUT_TWO = new Vector3d[]{
+            PASSENGER_OFFSETS[0],
+            PASSENGER_OFFSETS[1]
+    };
+    private static final Vector3d[] PASSENGER_LAYOUT_ONE = new Vector3d[]{
+            PASSENGER_OFFSETS[0]
+    };
+    private static final int MIN_PASSENGERS = 2;
 
     public DrakkarEntity(EntityType<? extends DrakkarEntity> type, World world) {
         super(type, world);
@@ -31,11 +67,6 @@ public class DrakkarEntity extends AbstractBasicShip {
         this.xo = x;
         this.yo = y;
         this.zo = z;
-    }
-
-    @Override
-    protected Vector3d[] getPassengerOffsets() {
-        return PASSENGER_OFFSETS;
     }
 
     @Override
@@ -60,7 +91,17 @@ public class DrakkarEntity extends AbstractBasicShip {
 
     @Override
     public int getInventorySize() {
-        return 18;
+        return SmallShipsConfig.DrakkarInventorySize.get();
+    }
+
+    @Override
+    public int getConfiguredInventoryPages() {
+        return SmallShipsConfig.DrakkarInventoryPages.get();
+    }
+
+    @Override
+    public int getMaxCannons() {
+        return SmallShipsConfig.DrakkarMaxCannons.get();
     }
 
     @Override
@@ -100,7 +141,7 @@ public class DrakkarEntity extends AbstractBasicShip {
 
     @Override
     public float getCannonModifier() {
-        return 0F;
+        return this.getTotalCannonCount() * 0.02F;
     }
 
     @Override
@@ -115,7 +156,100 @@ public class DrakkarEntity extends AbstractBasicShip {
 
     @Override
     public int getPassengerSize() {
-        return PASSENGER_OFFSETS.length;
+        int seatCount = PASSENGER_OFFSETS.length - (this.getTotalCannonCount() + 1) / 2;
+        return MathHelper.clamp(seatCount, MIN_PASSENGERS, PASSENGER_OFFSETS.length);
+    }
+
+    @Override
+    public ActionResultType interact(PlayerEntity player, Hand hand) {
+        ItemStack itemInHand = player.getItemInHand(hand);
+        if (player.isSecondaryUseActive()) {
+            if (this.getSunken()) {
+                if (!this.level.isClientSide) {
+                    ItemStack salvagedBoat = this.createShipItemStack(false);
+                    if (!salvagedBoat.isEmpty()) {
+                        if (salvagedBoat.isDamageableItem()) {
+                            salvagedBoat.setDamageValue(salvagedBoat.getMaxDamage());
+                        }
+                        ItemStack toGive = salvagedBoat.copy();
+                        if (!player.addItem(toGive)) {
+                            this.spawnAtLocation(salvagedBoat);
+                        }
+                    }
+                    setDropBrokenItemOnDestroy(false);
+                    this.destroyShip(DamageSource.GENERIC);
+                }
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
+
+            if (this.getPassengers().isEmpty()) {
+                if (!this.level.isClientSide) {
+                    setDropBrokenItemOnDestroy(false);
+                    this.spawnAtLocation(this.createShipItemStack(false));
+                    this.destroyShip(DamageSource.GENERIC);
+                }
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
+
+            if (this.isVehicle() && !(getControllingPassenger() instanceof PlayerEntity)) {
+                this.ejectPassengers();
+            } else if (!(getControllingPassenger() instanceof PlayerEntity)) {
+                InventoryEvents.openShipGUI(player, this, 0);
+            }
+
+            return ActionResultType.sidedSuccess(this.level.isClientSide);
+        }
+
+        if (!this.getSunken()) {
+            if (itemInHand.getItem() == ModItems.CANNON_ITEM.get()) {
+                this.onInteractionWithCannon(player, itemInHand);
+                return ActionResultType.SUCCESS;
+            }
+
+            if (!this.level.isClientSide) {
+                player.startRiding(this);
+            }
+            return ActionResultType.sidedSuccess(this.level.isClientSide);
+        }
+
+        return ActionResultType.PASS;
+    }
+
+    @Override
+    public void positionRider(Entity passenger) {
+        if (!hasPassenger(passenger)) {
+            return;
+        }
+
+        List<Entity> passengers = this.getPassengers();
+        int index = passengers.indexOf(passenger);
+        Vector3d[] layout = getSeatLayout();
+        if (layout.length == 0) {
+            return;
+        }
+        int seatIndex = MathHelper.clamp(index, 0, layout.length - 1);
+        Vector3d offset = layout[seatIndex];
+        float ridingOffset = (float) ((this.removed ? 0.02D : this.getPassengersRidingOffset()) + passenger.getMyRidingOffset());
+        Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
+                .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
+        passenger.setPos(this.getX() + rotated.x, this.getY() + ridingOffset, this.getZ() + rotated.z);
+        passenger.yRot += this.deltaRotation;
+        passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
+        applyYawToEntity(passenger);
+    }
+
+    private Vector3d[] getSeatLayout() {
+        int seatCount = MathHelper.clamp(this.getPassengerSize(), 1, PASSENGER_OFFSETS.length);
+        if (seatCount >= PASSENGER_LAYOUT_FIVE.length) {
+            return PASSENGER_LAYOUT_FIVE;
+        } else if (seatCount == 4) {
+            return PASSENGER_LAYOUT_FOUR;
+        } else if (seatCount == 3) {
+            return PASSENGER_LAYOUT_THREE;
+        } else if (seatCount == 2) {
+            return PASSENGER_LAYOUT_TWO;
+        }
+        return PASSENGER_LAYOUT_ONE;
     }
 
     @Override
@@ -145,5 +279,29 @@ public class DrakkarEntity extends AbstractBasicShip {
     @Override
     protected Item getBrokenHullItem() {
         return Items.AIR;
+    }
+
+    @Override
+    public void WaterSplash() {
+        Vector3d forward = this.getViewVector(0.0F);
+        float cos = MathHelper.cos(this.yRot * ((float) Math.PI / 180F)) * 0.6F;
+        float sin = MathHelper.sin(this.yRot * ((float) Math.PI / 180F)) * 0.6F;
+        for (int i = 0; i < 2; i++) {
+            this.level.addParticle(net.minecraft.particles.ParticleTypes.SPLASH,
+                    this.getX() - forward.x * 1.5D + cos,
+                    this.getY() + 0.2D,
+                    this.getZ() - forward.z * 1.5D + sin,
+                    0.0D, 0.0D, 0.0D);
+            this.level.addParticle(net.minecraft.particles.ParticleTypes.SPLASH,
+                    this.getX() - forward.x * 1.5D - cos,
+                    this.getY() + 0.2D,
+                    this.getZ() - forward.z * 1.5D - sin,
+                    0.0D, 0.0D, 0.0D);
+        }
+    }
+
+    @Override
+    public boolean getHasBanner() {
+        return false;
     }
 }

--- a/src/main/java/com/talhanation/smallships/entities/GalleyEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/GalleyEntity.java
@@ -93,7 +93,12 @@ public class GalleyEntity extends AbstractCannonShip {
 
     @Override
     public int getInventorySize() {
-        return 36;
+        return SmallShipsConfig.GalleyInventorySize.get();
+    }
+
+    @Override
+    public int getConfiguredInventoryPages() {
+        return SmallShipsConfig.GalleyInventoryPages.get();
     }
 
     @Override
@@ -154,7 +159,7 @@ public class GalleyEntity extends AbstractCannonShip {
 
     @Override
     public int getMaxCannons() {
-        return 4;
+        return SmallShipsConfig.GalleyMaxCannons.get();
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/entities/RowBoatEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/RowBoatEntity.java
@@ -1,21 +1,39 @@
 package com.talhanation.smallships.entities;
 
+import com.talhanation.smallships.InventoryEvents;
 import com.talhanation.smallships.config.SmallShipsConfig;
 import com.talhanation.smallships.init.ModEntityTypes;
 import com.talhanation.smallships.init.ModItems;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.Hand;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.world.World;
 
-public class RowBoatEntity extends AbstractBasicShip {
+import java.util.List;
+
+public class RowBoatEntity extends AbstractCannonShip {
 
     private static final Vector3d[] PASSENGER_OFFSETS = new Vector3d[]{
             new Vector3d(-0.5D, 0.0D, 0.0D),
             new Vector3d(0.5D, 0.0D, -0.4D)
     };
+    private static final Vector3d[] PASSENGER_LAYOUT_TWO = new Vector3d[]{
+            PASSENGER_OFFSETS[0],
+            PASSENGER_OFFSETS[1]
+    };
+    private static final Vector3d[] PASSENGER_LAYOUT_ONE = new Vector3d[]{
+            PASSENGER_OFFSETS[0]
+    };
+    private static final int MIN_PASSENGERS = 1;
 
     public RowBoatEntity(EntityType<? extends RowBoatEntity> type, World world) {
         super(type, world);
@@ -28,11 +46,6 @@ public class RowBoatEntity extends AbstractBasicShip {
         this.xo = x;
         this.yo = y;
         this.zo = z;
-    }
-
-    @Override
-    protected Vector3d[] getPassengerOffsets() {
-        return PASSENGER_OFFSETS;
     }
 
     @Override
@@ -57,7 +70,17 @@ public class RowBoatEntity extends AbstractBasicShip {
 
     @Override
     public int getInventorySize() {
-        return 9;
+        return SmallShipsConfig.RowBoatInventorySize.get();
+    }
+
+    @Override
+    public int getConfiguredInventoryPages() {
+        return SmallShipsConfig.RowBoatInventoryPages.get();
+    }
+
+    @Override
+    public int getMaxCannons() {
+        return SmallShipsConfig.RowBoatMaxCannons.get();
     }
 
     @Override
@@ -97,7 +120,7 @@ public class RowBoatEntity extends AbstractBasicShip {
 
     @Override
     public float getCannonModifier() {
-        return 0F;
+        return this.getTotalCannonCount() * 0.02F;
     }
 
     @Override
@@ -112,7 +135,94 @@ public class RowBoatEntity extends AbstractBasicShip {
 
     @Override
     public int getPassengerSize() {
-        return PASSENGER_OFFSETS.length;
+        int seatCount = PASSENGER_OFFSETS.length - (this.getTotalCannonCount() + 1) / 2;
+        return MathHelper.clamp(seatCount, MIN_PASSENGERS, PASSENGER_OFFSETS.length);
+    }
+
+    @Override
+    public ActionResultType interact(PlayerEntity player, Hand hand) {
+        ItemStack itemInHand = player.getItemInHand(hand);
+        if (player.isSecondaryUseActive()) {
+            if (this.getSunken()) {
+                if (!this.level.isClientSide) {
+                    ItemStack salvagedBoat = this.createShipItemStack(false);
+                    if (!salvagedBoat.isEmpty()) {
+                        if (salvagedBoat.isDamageableItem()) {
+                            salvagedBoat.setDamageValue(salvagedBoat.getMaxDamage());
+                        }
+                        ItemStack toGive = salvagedBoat.copy();
+                        if (!player.addItem(toGive)) {
+                            this.spawnAtLocation(salvagedBoat);
+                        }
+                    }
+                    setDropBrokenItemOnDestroy(false);
+                    this.destroyShip(DamageSource.GENERIC);
+                }
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
+
+            if (this.getPassengers().isEmpty()) {
+                if (!this.level.isClientSide) {
+                    setDropBrokenItemOnDestroy(false);
+                    this.spawnAtLocation(this.createShipItemStack(false));
+                    this.destroyShip(DamageSource.GENERIC);
+                }
+                return ActionResultType.sidedSuccess(this.level.isClientSide);
+            }
+
+            if (this.isVehicle() && !(getControllingPassenger() instanceof PlayerEntity)) {
+                this.ejectPassengers();
+            } else if (!(getControllingPassenger() instanceof PlayerEntity)) {
+                InventoryEvents.openShipGUI(player, this, 0);
+            }
+
+            return ActionResultType.sidedSuccess(this.level.isClientSide);
+        }
+
+        if (!this.getSunken()) {
+            if (itemInHand.getItem() == ModItems.CANNON_ITEM.get()) {
+                this.onInteractionWithCannon(player, itemInHand);
+                return ActionResultType.SUCCESS;
+            }
+
+            if (!this.level.isClientSide) {
+                player.startRiding(this);
+            }
+            return ActionResultType.sidedSuccess(this.level.isClientSide);
+        }
+
+        return ActionResultType.PASS;
+    }
+
+    @Override
+    public void positionRider(Entity passenger) {
+        if (!hasPassenger(passenger)) {
+            return;
+        }
+
+        List<Entity> passengers = this.getPassengers();
+        int index = passengers.indexOf(passenger);
+        Vector3d[] layout = getSeatLayout();
+        if (layout.length == 0) {
+            return;
+        }
+        int seatIndex = MathHelper.clamp(index, 0, layout.length - 1);
+        Vector3d offset = layout[seatIndex];
+        float ridingOffset = (float) ((this.removed ? 0.02D : this.getPassengersRidingOffset()) + passenger.getMyRidingOffset());
+        Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
+                .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
+        passenger.setPos(this.getX() + rotated.x, this.getY() + ridingOffset, this.getZ() + rotated.z);
+        passenger.yRot += this.deltaRotation;
+        passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
+        applyYawToEntity(passenger);
+    }
+
+    private Vector3d[] getSeatLayout() {
+        int seatCount = MathHelper.clamp(this.getPassengerSize(), 1, PASSENGER_OFFSETS.length);
+        if (seatCount <= 1) {
+            return PASSENGER_LAYOUT_ONE;
+        }
+        return PASSENGER_LAYOUT_TWO;
     }
 
     @Override
@@ -142,5 +252,29 @@ public class RowBoatEntity extends AbstractBasicShip {
     @Override
     protected Item getBrokenHullItem() {
         return Items.AIR;
+    }
+
+    @Override
+    public void WaterSplash() {
+        Vector3d forward = this.getViewVector(0.0F);
+        float cos = MathHelper.cos(this.yRot * ((float) Math.PI / 180F)) * 0.6F;
+        float sin = MathHelper.sin(this.yRot * ((float) Math.PI / 180F)) * 0.6F;
+        for (int i = 0; i < 2; i++) {
+            this.level.addParticle(net.minecraft.particles.ParticleTypes.SPLASH,
+                    this.getX() - forward.x * 1.5D + cos,
+                    this.getY() + 0.2D,
+                    this.getZ() - forward.z * 1.5D + sin,
+                    0.0D, 0.0D, 0.0D);
+            this.level.addParticle(net.minecraft.particles.ParticleTypes.SPLASH,
+                    this.getX() - forward.x * 1.5D - cos,
+                    this.getY() + 0.2D,
+                    this.getZ() - forward.z * 1.5D - sin,
+                    0.0D, 0.0D, 0.0D);
+        }
+    }
+
+    @Override
+    public boolean getHasBanner() {
+        return false;
     }
 }

--- a/src/main/java/com/talhanation/smallships/entities/WarGalleyEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/WarGalleyEntity.java
@@ -90,7 +90,12 @@ public class WarGalleyEntity extends AbstractCannonShip {
 
     @Override
     public int getInventorySize() {
-        return 36;
+        return SmallShipsConfig.WarGalleyInventorySize.get();
+    }
+
+    @Override
+    public int getConfiguredInventoryPages() {
+        return SmallShipsConfig.WarGalleyInventoryPages.get();
     }
 
     @Override
@@ -151,7 +156,7 @@ public class WarGalleyEntity extends AbstractCannonShip {
 
     @Override
     public int getMaxCannons() {
-        return 6;
+        return SmallShipsConfig.WarGalleyMaxCannons.get();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- recode the rowboat and drakkar to use cannon ship behavior and draw their limits from config values
- add config options for each ship to control inventory size, page count, and max cannon slots
- update the ship inventory UI and helpers to respect configurable page offsets

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65 in the bundled Gradle/Groovy tooling)*

------
https://chatgpt.com/codex/tasks/task_b_68d1629c4e7c832e9f74d5c09d244da6