### PR TITLE
Allow per-ship cannon placement and honor passenger heights

### DIFF
--- a/src/main/java/com/talhanation/smallships/client/render/RenderEntityBrigg.java
+++ b/src/main/java/com/talhanation/smallships/client/render/RenderEntityBrigg.java
@@ -81,7 +81,7 @@ public class RenderEntityBrigg extends AbstractShipRenderer<BriggEntity> {
 
     @Override
     protected void renderAdditionalParts(BriggEntity entity, float partialTicks, MatrixStack matrixStack, IRenderTypeBuffer buffer, int packedLight) {
-        entity.renderCannon(-0.75D, -0.55D, -90F, matrixStack, buffer, packedLight, partialTicks);
+        entity.renderCannons(matrixStack, buffer, packedLight, partialTicks);
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/client/render/RenderEntityCog.java
+++ b/src/main/java/com/talhanation/smallships/client/render/RenderEntityCog.java
@@ -86,7 +86,7 @@ public class RenderEntityCog extends AbstractShipRenderer<CogEntity> {
 
     @Override
     protected void renderAdditionalParts(CogEntity entity, float partialTicks, MatrixStack matrixStack, IRenderTypeBuffer buffer, int packedLight) {
-        entity.renderCannon(-0.65D, 0.03D, 0F, matrixStack, buffer, packedLight, partialTicks);
+        entity.renderCannons(matrixStack, buffer, packedLight, partialTicks);
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/client/render/RenderEntityDhow.java
+++ b/src/main/java/com/talhanation/smallships/client/render/RenderEntityDhow.java
@@ -49,7 +49,7 @@ public class RenderEntityDhow extends AbstractShipRenderer<DhowEntity> {
 
     @Override
     protected void renderAdditionalParts(DhowEntity entity, float partialTicks, MatrixStack matrixStack, IRenderTypeBuffer buffer, int packedLight) {
-        entity.renderCannon(-0.65D, 0.03D, 0F, matrixStack, buffer, packedLight, partialTicks);
+        entity.renderCannons(matrixStack, buffer, packedLight, partialTicks);
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/client/render/RenderEntityGalley.java
+++ b/src/main/java/com/talhanation/smallships/client/render/RenderEntityGalley.java
@@ -48,7 +48,7 @@ public class RenderEntityGalley extends AbstractShipRenderer<GalleyEntity> {
 
     @Override
     protected void renderAdditionalParts(GalleyEntity entity, float partialTicks, MatrixStack matrixStack, IRenderTypeBuffer buffer, int packedLight) {
-        entity.renderCannon(-0.75D, -0.55D, -90F, matrixStack, buffer, packedLight, partialTicks);
+        entity.renderCannons(matrixStack, buffer, packedLight, partialTicks);
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/client/render/RenderEntityWarGalley.java
+++ b/src/main/java/com/talhanation/smallships/client/render/RenderEntityWarGalley.java
@@ -48,7 +48,7 @@ public class RenderEntityWarGalley extends AbstractShipRenderer<WarGalleyEntity>
 
     @Override
     protected void renderAdditionalParts(WarGalleyEntity entity, float partialTicks, MatrixStack matrixStack, IRenderTypeBuffer buffer, int packedLight) {
-        entity.renderCannon(-0.75D, -0.55D, -90F, matrixStack, buffer, packedLight, partialTicks);
+        entity.renderCannons(matrixStack, buffer, packedLight, partialTicks);
     }
 
     @Override

--- a/src/main/java/com/talhanation/smallships/entities/AbstractCannonShip.java
+++ b/src/main/java/com/talhanation/smallships/entities/AbstractCannonShip.java
@@ -309,41 +309,39 @@ public abstract class AbstractCannonShip extends AbstractShipDamage{
         this.shrinkItemInInv(inventory, cannonballItem, 1);
     }
 
-    public void renderCannon(double Zoffset, double height, float angle, MatrixStack matrixStack, IRenderTypeBuffer buffer , int packedLight, float partialTicks) {
-        if (getLeftCannonCount() != 0) {
-            for (int i = 0; i < getLeftCannonCount(); i++) {
-                double offset = 0;
-                switch (i) {
-                    case 0:
-                        offset = 1;
-                        break;
-                    case 1:
-                        offset = -0.2;
-                        break;
-                    case 2:
-                        offset = -1.5;
-                        break;
-                }
-                RenderCannon.renderCannon(Zoffset, offset, height, angle,this, partialTicks, matrixStack, buffer, packedLight);
-            }
+    public void renderCannons(MatrixStack matrixStack, IRenderTypeBuffer buffer, int packedLight, float partialTicks) {
+        renderCannonSide(this.getLeftCannonOffsets(), this.getLeftCannonCount(), this.getLeftCannonRotation(), matrixStack, buffer, packedLight, partialTicks);
+        renderCannonSide(this.getRightCannonOffsets(), this.getRightCannonCount(), this.getRightCannonRotation(), matrixStack, buffer, packedLight, partialTicks);
+    }
+
+    private void renderCannonSide(Vector3d[] offsets, int cannonCount, float angle, MatrixStack matrixStack, IRenderTypeBuffer buffer, int packedLight, float partialTicks) {
+        if (offsets == null || cannonCount <= 0) {
+            return;
         }
-        if (getRightCannonCount() != 0) {
-            for (int i = 0; i < getRightCannonCount(); i++) {
-                double offset = 0;
-                switch (i) {
-                    case 0:
-                        offset = -1;
-                        break;
-                    case 1:
-                        offset = 0.2;
-                        break;
-                    case 2:
-                        offset = 1.5;
-                        break;
-                }
-                RenderCannon.renderCannon(Zoffset, offset, height, angle + 180, this, partialTicks, matrixStack, buffer, packedLight);
-            }
+
+        int renderCount = Math.min(cannonCount, offsets.length);
+        float radians = (float) Math.toRadians(-angle);
+        for (int i = 0; i < renderCount; i++) {
+            Vector3d offset = offsets[i];
+            Vector3d local = offset.yRot(radians);
+            RenderCannon.renderCannon(local.z, local.x, local.y, angle, this, partialTicks, matrixStack, buffer, packedLight);
         }
+    }
+
+    protected Vector3d[] getLeftCannonOffsets() {
+        return new Vector3d[0];
+    }
+
+    protected Vector3d[] getRightCannonOffsets() {
+        return new Vector3d[0];
+    }
+
+    protected float getLeftCannonRotation() {
+        return -90F;
+    }
+
+    protected float getRightCannonRotation() {
+        return getLeftCannonRotation() + 180F;
     }
 
     public void onInteractionWithCannon(PlayerEntity player, ItemStack itemStack) {

--- a/src/main/java/com/talhanation/smallships/entities/BriggEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/BriggEntity.java
@@ -19,6 +19,17 @@ import net.minecraft.world.World;
 
 public class BriggEntity extends AbstractCannonShip{
 
+    private static final Vector3d[] LEFT_CANNON_OFFSETS = new Vector3d[]{
+            new Vector3d(-1.8D, -0.55D, 1.4D),
+            new Vector3d(-1.8D, -0.55D, 0.0D),
+            new Vector3d(-1.8D, -0.55D, -1.4D)
+    };
+    private static final Vector3d[] RIGHT_CANNON_OFFSETS = new Vector3d[]{
+            new Vector3d(1.8D, -0.55D, 1.4D),
+            new Vector3d(1.8D, -0.55D, 0.0D),
+            new Vector3d(1.8D, -0.55D, -1.4D)
+    };
+
     public BriggEntity(EntityType<? extends BriggEntity> type, World world) {
         super(type, world);
     }
@@ -491,5 +502,15 @@ public class BriggEntity extends AbstractCannonShip{
             //passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
             applyYawToEntity(passenger);
         }
+    }
+
+    @Override
+    protected Vector3d[] getLeftCannonOffsets() {
+        return LEFT_CANNON_OFFSETS;
+    }
+
+    @Override
+    protected Vector3d[] getRightCannonOffsets() {
+        return RIGHT_CANNON_OFFSETS;
     }
 }

--- a/src/main/java/com/talhanation/smallships/entities/CogEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/CogEntity.java
@@ -19,6 +19,15 @@ import net.minecraft.world.World;
 
 public class CogEntity extends AbstractCannonShip{
 
+    private static final Vector3d[] LEFT_CANNON_OFFSETS = new Vector3d[]{
+            new Vector3d(-1.4D, 0.03D, 1.1D),
+            new Vector3d(-1.4D, 0.03D, -1.1D)
+    };
+    private static final Vector3d[] RIGHT_CANNON_OFFSETS = new Vector3d[]{
+        new Vector3d(1.4D, 0.03D, 1.1D),
+        new Vector3d(1.4D, 0.03D, -1.1D)
+    };
+
     public CogEntity(EntityType<? extends CogEntity> type, World world) {
         super(type, world);
     }
@@ -77,6 +86,16 @@ public class CogEntity extends AbstractCannonShip{
     @Override
     public float getAcceleration() {
         return 0.015F; //sensible
+    }
+
+    @Override
+    protected float getLeftCannonRotation() {
+        return 0F;
+    }
+
+    @Override
+    protected float getRightCannonRotation() {
+        return 180F;
     }
 
     @Override
@@ -355,5 +374,15 @@ public class CogEntity extends AbstractCannonShip{
             applyYawToEntity(passenger);
         }
 
+    }
+
+    @Override
+    protected Vector3d[] getLeftCannonOffsets() {
+        return LEFT_CANNON_OFFSETS;
+    }
+
+    @Override
+    protected Vector3d[] getRightCannonOffsets() {
+        return RIGHT_CANNON_OFFSETS;
     }
 }

--- a/src/main/java/com/talhanation/smallships/entities/DhowEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/DhowEntity.java
@@ -29,6 +29,14 @@ public class DhowEntity extends AbstractCannonShip {
             new Vector3d(-2.0D, 0.8D, -0.6D), // en bas à gauche
             new Vector3d(0D, 0.5D, -0.6D) // en haut à gauche
     };
+    private static final Vector3d[] LEFT_CANNON_OFFSETS = new Vector3d[]{
+            new Vector3d(-1.2D, 0.03D, 0.85D),
+            new Vector3d(-1.2D, 0.03D, -0.85D)
+    };
+    private static final Vector3d[] RIGHT_CANNON_OFFSETS = new Vector3d[]{
+            new Vector3d(1.2D, 0.03D, 0.85D),
+            new Vector3d(1.2D, 0.03D, -0.85D)
+    };
     private static final Vector3d[] PASSENGER_LAYOUT_FOUR = new Vector3d[]{
             PASSENGER_OFFSETS[0],
             PASSENGER_OFFSETS[1],
@@ -266,7 +274,7 @@ public class DhowEntity extends AbstractCannonShip {
         float ridingOffset = (float) ((this.removed ? 0.02D : this.getPassengersRidingOffset()) + passenger.getMyRidingOffset());
         Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
                 .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
-        passenger.setPos(this.getX() + rotated.x, this.getY() + rotated.y + ridingOffset, this.getZ() + rotated.z);
+        passenger.setPos(this.getX() + rotated.x, this.getY() + offset.y + ridingOffset, this.getZ() + rotated.z);
         passenger.yRot += this.deltaRotation;
         passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
         applyYawToEntity(passenger);
@@ -306,5 +314,25 @@ public class DhowEntity extends AbstractCannonShip {
     @Override
     public boolean getHasBanner() {
         return false;
+    }
+
+    @Override
+    protected Vector3d[] getLeftCannonOffsets() {
+        return LEFT_CANNON_OFFSETS;
+    }
+
+    @Override
+    protected Vector3d[] getRightCannonOffsets() {
+        return RIGHT_CANNON_OFFSETS;
+    }
+
+    @Override
+    protected float getLeftCannonRotation() {
+        return 0F;
+    }
+
+    @Override
+    protected float getRightCannonRotation() {
+        return 180F;
     }
 }

--- a/src/main/java/com/talhanation/smallships/entities/DrakkarEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/DrakkarEntity.java
@@ -232,7 +232,7 @@ public class DrakkarEntity extends AbstractCannonShip {
         float ridingOffset = (float) ((this.removed ? 0.02D : this.getPassengersRidingOffset()) + passenger.getMyRidingOffset());
         Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
                 .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
-        passenger.setPos(this.getX() + rotated.x, this.getY() + ridingOffset, this.getZ() + rotated.z);
+        passenger.setPos(this.getX() + rotated.x, this.getY() + offset.y + ridingOffset, this.getZ() + rotated.z);
         passenger.yRot += this.deltaRotation;
         passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
         applyYawToEntity(passenger);

--- a/src/main/java/com/talhanation/smallships/entities/GalleyEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/GalleyEntity.java
@@ -31,6 +31,16 @@ public class GalleyEntity extends AbstractCannonShip {
             new Vector3d(-0.4D, 0.0D, -1.3D),
             new Vector3d(0.4D, 0.0D, -1.3D)
     };
+    private static final Vector3d[] LEFT_CANNON_OFFSETS = new Vector3d[]{
+            new Vector3d(-1.4D, -0.55D, 0.6D),
+            new Vector3d(-1.4D, -0.55D, -0.4D),
+            new Vector3d(-1.4D, -0.55D, -1.4D)
+    };
+    private static final Vector3d[] RIGHT_CANNON_OFFSETS = new Vector3d[]{
+            new Vector3d(1.4D, -0.55D, 0.6D),
+            new Vector3d(1.4D, -0.55D, -0.4D),
+            new Vector3d(1.4D, -0.55D, -1.4D)
+    };
     private static final Vector3d[] PASSENGER_LAYOUT_FIVE = new Vector3d[]{
             PASSENGER_OFFSETS[0],
             PASSENGER_OFFSETS[1],
@@ -276,7 +286,7 @@ public class GalleyEntity extends AbstractCannonShip {
         float ridingOffset = (float) ((this.removed ? 0.02D : this.getPassengersRidingOffset()) + passenger.getMyRidingOffset());
         Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
                 .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
-        passenger.setPos(this.getX() + rotated.x, this.getY() + ridingOffset, this.getZ() + rotated.z);
+        passenger.setPos(this.getX() + rotated.x, this.getY() + offset.y + ridingOffset, this.getZ() + rotated.z);
         passenger.yRot += this.deltaRotation;
         passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
         applyYawToEntity(passenger);
@@ -322,5 +332,15 @@ public class GalleyEntity extends AbstractCannonShip {
     @Override
     public boolean getHasBanner() {
         return false;
+    }
+
+    @Override
+    protected Vector3d[] getLeftCannonOffsets() {
+        return LEFT_CANNON_OFFSETS;
+    }
+
+    @Override
+    protected Vector3d[] getRightCannonOffsets() {
+        return RIGHT_CANNON_OFFSETS;
     }
 }

--- a/src/main/java/com/talhanation/smallships/entities/RowBoatEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/RowBoatEntity.java
@@ -211,7 +211,7 @@ public class RowBoatEntity extends AbstractCannonShip {
         float ridingOffset = (float) ((this.removed ? 0.02D : this.getPassengersRidingOffset()) + passenger.getMyRidingOffset());
         Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
                 .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
-        passenger.setPos(this.getX() + rotated.x, this.getY() + ridingOffset, this.getZ() + rotated.z);
+        passenger.setPos(this.getX() + rotated.x, this.getY() + offset.y + ridingOffset, this.getZ() + rotated.z);
         passenger.yRot += this.deltaRotation;
         passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
         applyYawToEntity(passenger);

--- a/src/main/java/com/talhanation/smallships/entities/WarGalleyEntity.java
+++ b/src/main/java/com/talhanation/smallships/entities/WarGalleyEntity.java
@@ -28,6 +28,16 @@ public class WarGalleyEntity extends AbstractCannonShip {
             new Vector3d(-0.6D, 0.0D, -1.3D),
             new Vector3d(0.6D, 0.0D, -1.3D)
     };
+    private static final Vector3d[] LEFT_CANNON_OFFSETS = new Vector3d[]{
+            new Vector3d(-1.6D, -0.55D, 0.7D),
+            new Vector3d(-1.6D, -0.55D, -0.3D),
+            new Vector3d(-1.6D, -0.55D, -1.4D)
+    };
+    private static final Vector3d[] RIGHT_CANNON_OFFSETS = new Vector3d[]{
+            new Vector3d(1.6D, -0.55D, 0.7D),
+            new Vector3d(1.6D, -0.55D, -0.3D),
+            new Vector3d(1.6D, -0.55D, -1.4D)
+    };
     private static final Vector3d[] PASSENGER_LAYOUT_FIVE = new Vector3d[]{
             PASSENGER_OFFSETS[0],
             PASSENGER_OFFSETS[1],
@@ -286,7 +296,7 @@ public class WarGalleyEntity extends AbstractCannonShip {
         float ridingOffset = (float) ((this.removed ? 0.02D : this.getPassengersRidingOffset()) + passenger.getMyRidingOffset());
         Vector3d rotated = new Vector3d(offset.x, 0.0D, offset.z)
                 .yRot(-this.yRot * ((float) Math.PI / 180F) - ((float) Math.PI / 2F));
-        passenger.setPos(this.getX() + rotated.x, this.getY() + ridingOffset, this.getZ() + rotated.z);
+        passenger.setPos(this.getX() + rotated.x, this.getY() + offset.y + ridingOffset, this.getZ() + rotated.z);
         passenger.yRot += this.deltaRotation;
         passenger.setYHeadRot(passenger.getYHeadRot() + this.deltaRotation);
         applyYawToEntity(passenger);
@@ -327,5 +337,15 @@ public class WarGalleyEntity extends AbstractCannonShip {
                     this.getZ() - forward.z * 1.8D - sin,
                     0.0D, 0.0D, 0.0D);
         }
+    }
+
+    @Override
+    protected Vector3d[] getLeftCannonOffsets() {
+        return LEFT_CANNON_OFFSETS;
+    }
+
+    @Override
+    protected Vector3d[] getRightCannonOffsets() {
+        return RIGHT_CANNON_OFFSETS;
     }
 }


### PR DESCRIPTION
## Summary
- replace the shared cannon placement routine with per-ship offset arrays and orientation hooks
- define cannon layouts for the Dhow, Cog, Galley, War Galley and Brigg so their models render cannons in the right spots
- honor the Y component of passenger offsets when positioning riders across ship entities

## Testing
- `./gradlew compileJava` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_b_68d6cd1677b88333b5a703be82904770